### PR TITLE
update versions

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -17,6 +17,16 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+      - name: Configure private NuGet source (FsGrpc.Tools 0.8.0)
+        env:
+          NUGET_SOURCE_URL: ${{ secrets.NUGET_SOURCE_URL }}
+          NUGET_SOURCE_NAME: ${{ secrets.NUGET_SOURCE_NAME }}
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          if [ -n "$NUGET_SOURCE_URL" ] && [ -n "$NUGET_SOURCE_NAME" ] && [ -n "$NUGET_API_KEY" ]; then
+            dotnet nuget remove source "$NUGET_SOURCE_NAME" || true
+            dotnet nuget add source "$NUGET_SOURCE_URL" --name "$NUGET_SOURCE_NAME" --username "token" --password "$NUGET_API_KEY" --store-password-in-clear-text || true
+          fi
       - name: Display SDK versions
         run: dotnet --list-sdks
       - name: Gather projects

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -17,15 +17,25 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+          # If using GitHub Packages for FsGrpc.Tools, set source-url to your org feed
+          source-url: ${{ secrets.NUGET_SOURCE_URL }}
+        env:
+          # setup-dotnet will configure auth for source-url using this token
+          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure private NuGet source (FsGrpc.Tools 0.8.0)
         env:
           NUGET_SOURCE_URL: ${{ secrets.NUGET_SOURCE_URL }}
           NUGET_SOURCE_NAME: ${{ secrets.NUGET_SOURCE_NAME }}
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ -n "$NUGET_SOURCE_URL" ] && [ -n "$NUGET_SOURCE_NAME" ] && [ -n "$NUGET_API_KEY" ]; then
+          if [ -n "$NUGET_SOURCE_URL" ] && [ -n "$NUGET_SOURCE_NAME" ]; then
             dotnet nuget remove source "$NUGET_SOURCE_NAME" || true
-            dotnet nuget add source "$NUGET_SOURCE_URL" --name "$NUGET_SOURCE_NAME" --username "token" --password "$NUGET_API_KEY" --store-password-in-clear-text || true
+            dotnet nuget add source "$NUGET_SOURCE_URL" \
+              --name "$NUGET_SOURCE_NAME" \
+              --username "$GITHUB_ACTOR" \
+              --password "$GITHUB_TOKEN" \
+              --store-password-in-clear-text \
+              --valid-authentication-types basic || true
           fi
       - name: Display SDK versions
         run: dotnet --list-sdks

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -25,16 +25,16 @@ jobs:
             dotnet new sln -n protoc-gen-fsgrpc-ci && \
             dotnet sln protoc-gen-fsgrpc-ci.sln add `find . -type f -name '*.fsproj'` --in-root
       - name: Install dependencies
-        run: dotnet restore
+        run: dotnet restore protoc-gen-fsgrpc-ci.sln
       - name: Build
         run: |
-          dotnet build \
+          dotnet build protoc-gen-fsgrpc-ci.sln \
             -p:TargetFramework=net${{ matrix.dotnet-version }} \
             --configuration Release \
             --no-restore
       - name: Test
         run: |
-          dotnet test \
+          dotnet test protoc-gen-fsgrpc-ci.sln \
             -p:TargetFramework=net${{ matrix.dotnet-version }} \
             --configuration Release \
             --no-restore \

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -5,12 +5,19 @@ on:
       branches:
         - main
   workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         dotnet-version: ['8.0']
+    env:
+      ORG_NUGET_FEED: https://nuget.pkg.github.com/dmgtech/index.json
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET Core SDKs
@@ -18,10 +25,8 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
-          # If using GitHub Packages for FsGrpc.Tools, set source-url to your org feed
-          source-url: ${{ secrets.NUGET_SOURCE_URL }}
+          source-url: ${{ secrets.NUGET_SOURCE_URL || env.ORG_NUGET_FEED }}
         env:
-          # setup-dotnet will configure auth for source-url using this token
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure private NuGet source (FsGrpc.Tools 0.8.0)
         env:
@@ -29,7 +34,9 @@ jobs:
           NUGET_SOURCE_NAME: ${{ secrets.NUGET_SOURCE_NAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ -n "$NUGET_SOURCE_URL" ] && [ -n "$NUGET_SOURCE_NAME" ]; then
+          # Fallback to org feed if secret not set (e.g., PRs from forks)
+          NUGET_SOURCE_URL=${NUGET_SOURCE_URL:-$ORG_NUGET_FEED}
+          if [ -n "$NUGET_SOURCE_NAME" ]; then
             dotnet nuget remove source "$NUGET_SOURCE_NAME" || true
             dotnet nuget add source "$NUGET_SOURCE_URL" \
               --name "$NUGET_SOURCE_NAME" \
@@ -37,6 +44,12 @@ jobs:
               --password "$GITHUB_TOKEN" \
               --store-password-in-clear-text \
               --valid-authentication-types basic || true
+          else
+            # Use default name when not provided
+            dotnet nuget remove source dmgtech || true
+            dotnet nuget add source "$NUGET_SOURCE_URL" --name dmgtech \
+              --username "$GITHUB_ACTOR" --password "$GITHUB_TOKEN" \
+              --store-password-in-clear-text --valid-authentication-types basic || true
           fi
       - name: Display SDK versions
         run: dotnet --list-sdks
@@ -52,19 +65,16 @@ jobs:
         run: |
           echo "NuGet sources configured:" && dotnet nuget list source --format detailed || true
 
-          if [ -n "$NUGET_SOURCE_URL" ]; then
-            echo "Testing access to GitHub Packages feed..."
-            AUTH_B64=$(printf "%s:%s" "$GITHUB_ACTOR" "$GITHUB_TOKEN" | base64)
-            # Expect HTTP/200 from index.json when authenticated
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Basic $AUTH_B64" "$NUGET_SOURCE_URL")
-            echo "Feed URL: $NUGET_SOURCE_URL | HTTP status: $STATUS"
+          # Determine feed URL
+          FEED_URL=${NUGET_SOURCE_URL:-$ORG_NUGET_FEED}
 
-            echo "Restoring with explicit sources (GitHub feed + nuget.org)"
-            dotnet restore protoc-gen-fsgrpc-ci.sln --source "$NUGET_SOURCE_URL" --source https://api.nuget.org/v3/index.json --verbosity minimal
-          else
-            echo "NUGET_SOURCE_URL not set. Restoring with default sources (likely nuget.org only)."
-            dotnet restore protoc-gen-fsgrpc-ci.sln --verbosity minimal
-          fi
+          echo "Testing access to GitHub Packages feed..."
+          AUTH_B64=$(printf "%s:%s" "$GITHUB_ACTOR" "$GITHUB_TOKEN" | base64)
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Basic $AUTH_B64" "$FEED_URL")
+          echo "Feed URL: $FEED_URL | HTTP status: $STATUS"
+
+          echo "Restoring with explicit sources (GitHub feed + nuget.org)"
+          dotnet restore protoc-gen-fsgrpc-ci.sln --source "$FEED_URL" --source https://api.nuget.org/v3/index.json --verbosity minimal
       - name: Build
         run: |
           dotnet build protoc-gen-fsgrpc-ci.sln \

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
       branches:
         - main
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -16,7 +16,6 @@ jobs:
         uses: actions/setup-dotnet@v2.0.0
         with:
           dotnet-version: |
-            6.0.x
             8.0.x
       - name: Display SDK versions
         run: dotnet --list-sdks

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -45,8 +45,26 @@ jobs:
           rm -f protoc-gen-fsgrpc-ci.sln && \
             dotnet new sln -n protoc-gen-fsgrpc-ci && \
             dotnet sln protoc-gen-fsgrpc-ci.sln add `find . -type f -name '*.fsproj'` --in-root
-      - name: Install dependencies
-        run: dotnet restore protoc-gen-fsgrpc-ci.sln
+      - name: Install dependencies (with diagnostics)
+        env:
+          NUGET_SOURCE_URL: ${{ secrets.NUGET_SOURCE_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "NuGet sources configured:" && dotnet nuget list source --format detailed || true
+
+          if [ -n "$NUGET_SOURCE_URL" ]; then
+            echo "Testing access to GitHub Packages feed..."
+            AUTH_B64=$(printf "%s:%s" "$GITHUB_ACTOR" "$GITHUB_TOKEN" | base64)
+            # Expect HTTP/200 from index.json when authenticated
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Basic $AUTH_B64" "$NUGET_SOURCE_URL")
+            echo "Feed URL: $NUGET_SOURCE_URL | HTTP status: $STATUS"
+
+            echo "Restoring with explicit sources (GitHub feed + nuget.org)"
+            dotnet restore protoc-gen-fsgrpc-ci.sln --source "$NUGET_SOURCE_URL" --source https://api.nuget.org/v3/index.json --verbosity minimal
+          else
+            echo "NUGET_SOURCE_URL not set. Restoring with default sources (likely nuget.org only)."
+            dotnet restore protoc-gen-fsgrpc-ci.sln --verbosity minimal
+          fi
       - name: Build
         run: |
           dotnet build protoc-gen-fsgrpc-ci.sln \

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-dotnet@v2.0.0
         with:
           dotnet-version: |
-            6.0.x
             8.0.x
       - name: Display version
         run: dotnet --version

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -3,6 +3,7 @@ name: dotnet package
 on:
   push:
     tags: [v*.*]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -24,23 +24,23 @@ jobs:
       - name: Display version
         run: dotnet --version
       - name: Install dependencies
-        run: dotnet restore
+        run: dotnet restore protoc-gen-fsgrpc.fsproj
       - name: Build linux-arm64
-        run: dotnet build -p:TargetFramework=net${{ matrix.dotnet-version }} --no-self-contained --configuration Release --no-restore -r linux-arm64
+        run: dotnet build protoc-gen-fsgrpc.fsproj -p:TargetFramework=net${{ matrix.dotnet-version }} --no-self-contained --configuration Release --no-restore -r linux-arm64
       - name: Build linux-x64
-        run: dotnet build -p:TargetFramework=net${{ matrix.dotnet-version }} --no-self-contained --configuration Release --no-restore -r linux-x64
+        run: dotnet build protoc-gen-fsgrpc.fsproj -p:TargetFramework=net${{ matrix.dotnet-version }} --no-self-contained --configuration Release --no-restore -r linux-x64
       - name: Build osx-x64
-        run: dotnet build -p:TargetFramework=net${{ matrix.dotnet-version }} --no-self-contained --configuration Release --no-restore -r osx-x64
+        run: dotnet build protoc-gen-fsgrpc.fsproj -p:TargetFramework=net${{ matrix.dotnet-version }} --no-self-contained --configuration Release --no-restore -r osx-x64
       - name: Build osx-arm64
-        run: dotnet build -p:TargetFramework=net${{ matrix.dotnet-version }} --no-self-contained --configuration Release --no-restore -r osx-arm64
+        run: dotnet build protoc-gen-fsgrpc.fsproj -p:TargetFramework=net${{ matrix.dotnet-version }} --no-self-contained --configuration Release --no-restore -r osx-arm64
       - name: Build win-x86
-        run: dotnet build -p:TargetFramework=net${{ matrix.dotnet-version }} --no-self-contained --configuration Release --no-restore -r win-x86
+        run: dotnet build protoc-gen-fsgrpc.fsproj -p:TargetFramework=net${{ matrix.dotnet-version }} --no-self-contained --configuration Release --no-restore -r win-x86
       - name: Build win-x64
-        run: dotnet build -p:TargetFramework=net${{ matrix.dotnet-version }} --no-self-contained --configuration Release --no-restore -r win-x64
+        run: dotnet build protoc-gen-fsgrpc.fsproj -p:TargetFramework=net${{ matrix.dotnet-version }} --no-self-contained --configuration Release --no-restore -r win-x64
       - name: Package
         env:
           PROTOCGENFSGRPC_VERSION: ${{github.ref_name}}
-        run: dotnet pack -p:PROTOCGENFSGRPC_VERSION=${PROTOCGENFSGRPC_VERSION#v} --no-restore --no-build --configuration Release
+        run: dotnet pack protoc-gen-fsgrpc.fsproj -p:PROTOCGENFSGRPC_VERSION=${PROTOCGENFSGRPC_VERSION#v} --no-restore --no-build --configuration Release
       - name: Nuget Push
         env:
           PROTOCGENFSGRPC_VERSION: ${{github.ref_name}}

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -5,6 +5,10 @@ on:
     tags: [v*.*]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,6 +18,8 @@ jobs:
     defaults:
       run:
         working-directory: ./protoc-gen-fsgrpc
+    env:
+      ORG_NUGET_FEED: https://nuget.pkg.github.com/dmgtech/index.json
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -22,7 +28,7 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
-          source-url: ${{ secrets.NUGET_SOURCE_URL }}
+          source-url: ${{ secrets.NUGET_SOURCE_URL || env.ORG_NUGET_FEED }}
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure private NuGet source (FsGrpc.Tools 0.8.0)
@@ -31,9 +37,13 @@ jobs:
           NUGET_SOURCE_NAME: ${{ secrets.NUGET_SOURCE_NAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ -n "$NUGET_SOURCE_URL" ] && [ -n "$NUGET_SOURCE_NAME" ]; then
+          NUGET_SOURCE_URL=${NUGET_SOURCE_URL:-$ORG_NUGET_FEED}
+          if [ -n "$NUGET_SOURCE_NAME" ]; then
             dotnet nuget remove source "$NUGET_SOURCE_NAME" || true
             dotnet nuget add source "$NUGET_SOURCE_URL" --name "$NUGET_SOURCE_NAME" --username "$GITHUB_ACTOR" --password "$GITHUB_TOKEN" --store-password-in-clear-text --valid-authentication-types basic || true
+          else
+            dotnet nuget remove source dmgtech || true
+            dotnet nuget add source "$NUGET_SOURCE_URL" --name dmgtech --username "$GITHUB_ACTOR" --password "$GITHUB_TOKEN" --store-password-in-clear-text --valid-authentication-types basic || true
           fi
       - name: Display version
         run: dotnet --version
@@ -41,11 +51,8 @@ jobs:
         env:
           NUGET_SOURCE_URL: ${{ secrets.NUGET_SOURCE_URL }}
         run: |
-          if [ -n "$NUGET_SOURCE_URL" ]; then
-            dotnet restore protoc-gen-fsgrpc.fsproj --source "$NUGET_SOURCE_URL" --source https://api.nuget.org/v3/index.json
-          else
-            dotnet restore protoc-gen-fsgrpc.fsproj
-          fi
+          FEED_URL=${NUGET_SOURCE_URL:-$ORG_NUGET_FEED}
+          dotnet restore protoc-gen-fsgrpc.fsproj --source "$FEED_URL" --source https://api.nuget.org/v3/index.json
       - name: Build linux-arm64
         run: dotnet build protoc-gen-fsgrpc.fsproj -p:TargetFramework=net${{ matrix.dotnet-version }} --no-self-contained --configuration Release --no-restore -r linux-arm64
       - name: Build linux-x64
@@ -68,9 +75,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NUGET_SOURCE_URL: ${{ secrets.NUGET_SOURCE_URL }}
         run: |
+          FEED_URL=${NUGET_SOURCE_URL:-$ORG_NUGET_FEED}
           dotnet nuget push bin/Release/FsGrpc.ProtocGenFsGrpc.${PROTOCGENFSGRPC_VERSION#v}.nupkg \
             --api-key "$GITHUB_TOKEN" \
-            --source "$NUGET_SOURCE_URL" \
+            --source "$FEED_URL" \
             --skip-duplicate
       - name: GitHubRelease
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -22,20 +22,30 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+          source-url: ${{ secrets.NUGET_SOURCE_URL }}
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure private NuGet source (FsGrpc.Tools 0.8.0)
         env:
           NUGET_SOURCE_URL: ${{ secrets.NUGET_SOURCE_URL }}
           NUGET_SOURCE_NAME: ${{ secrets.NUGET_SOURCE_NAME }}
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ -n "$NUGET_SOURCE_URL" ] && [ -n "$NUGET_SOURCE_NAME" ] && [ -n "$NUGET_API_KEY" ]; then
+          if [ -n "$NUGET_SOURCE_URL" ] && [ -n "$NUGET_SOURCE_NAME" ]; then
             dotnet nuget remove source "$NUGET_SOURCE_NAME" || true
-            dotnet nuget add source "$NUGET_SOURCE_URL" --name "$NUGET_SOURCE_NAME" --username "token" --password "$NUGET_API_KEY" --store-password-in-clear-text || true
+            dotnet nuget add source "$NUGET_SOURCE_URL" --name "$NUGET_SOURCE_NAME" --username "$GITHUB_ACTOR" --password "$GITHUB_TOKEN" --store-password-in-clear-text --valid-authentication-types basic || true
           fi
       - name: Display version
         run: dotnet --version
-      - name: Install dependencies
-        run: dotnet restore protoc-gen-fsgrpc.fsproj
+      - name: Install dependencies (with explicit sources)
+        env:
+          NUGET_SOURCE_URL: ${{ secrets.NUGET_SOURCE_URL }}
+        run: |
+          if [ -n "$NUGET_SOURCE_URL" ]; then
+            dotnet restore protoc-gen-fsgrpc.fsproj --source "$NUGET_SOURCE_URL" --source https://api.nuget.org/v3/index.json
+          else
+            dotnet restore protoc-gen-fsgrpc.fsproj
+          fi
       - name: Build linux-arm64
         run: dotnet build protoc-gen-fsgrpc.fsproj -p:TargetFramework=net${{ matrix.dotnet-version }} --no-self-contained --configuration Release --no-restore -r linux-arm64
       - name: Build linux-x64
@@ -52,11 +62,16 @@ jobs:
         env:
           PROTOCGENFSGRPC_VERSION: ${{github.ref_name}}
         run: dotnet pack protoc-gen-fsgrpc.fsproj -p:PROTOCGENFSGRPC_VERSION=${PROTOCGENFSGRPC_VERSION#v} --no-restore --no-build --configuration Release
-      - name: Nuget Push
+      - name: Nuget Push (GitHub Packages)
         env:
           PROTOCGENFSGRPC_VERSION: ${{github.ref_name}}
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: dotnet nuget push bin/Release/FsGrpc.ProtocGenFsGrpc.${PROTOCGENFSGRPC_VERSION#v}.nupkg --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUGET_SOURCE_URL: ${{ secrets.NUGET_SOURCE_URL }}
+        run: |
+          dotnet nuget push bin/Release/FsGrpc.ProtocGenFsGrpc.${PROTOCGENFSGRPC_VERSION#v}.nupkg \
+            --api-key "$GITHUB_TOKEN" \
+            --source "$NUGET_SOURCE_URL" \
+            --skip-duplicate
       - name: GitHubRelease
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -21,6 +21,16 @@ jobs:
         with:
           dotnet-version: |
             8.0.x
+      - name: Configure private NuGet source (FsGrpc.Tools 0.8.0)
+        env:
+          NUGET_SOURCE_URL: ${{ secrets.NUGET_SOURCE_URL }}
+          NUGET_SOURCE_NAME: ${{ secrets.NUGET_SOURCE_NAME }}
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          if [ -n "$NUGET_SOURCE_URL" ] && [ -n "$NUGET_SOURCE_NAME" ] && [ -n "$NUGET_API_KEY" ]; then
+            dotnet nuget remove source "$NUGET_SOURCE_NAME" || true
+            dotnet nuget add source "$NUGET_SOURCE_URL" --name "$NUGET_SOURCE_NAME" --username "token" --password "$NUGET_API_KEY" --store-password-in-clear-text || true
+          fi
       - name: Display version
         run: dotnet --version
       - name: Install dependencies

--- a/FsGrpc.ProtocGenFsGrpc.sln
+++ b/FsGrpc.ProtocGenFsGrpc.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "protoc-gen-fsgrpc", "protoc-gen-fsgrpc\protoc-gen-fsgrpc.fsproj", "{3C9AD461-4B9A-4FAD-A6D4-54BCDDE64ABE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3C9AD461-4B9A-4FAD-A6D4-54BCDDE64ABE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C9AD461-4B9A-4FAD-A6D4-54BCDDE64ABE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C9AD461-4B9A-4FAD-A6D4-54BCDDE64ABE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C9AD461-4B9A-4FAD-A6D4-54BCDDE64ABE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/STRUCT_SUPPORT_ANALYSIS.md
+++ b/STRUCT_SUPPORT_ANALYSIS.md
@@ -1,0 +1,688 @@
+# Summary: Google.Protobuf.Struct Support Analysis for protoc-gen-fsgrpc
+
+## Executive Summary
+
+After thorough analysis of the `protoc-gen-fsgrpc` codebase and the requirements outlined in `struct-support-implementation-guide.md`, I conclude that **NO CODE CHANGES are required in the protoc-gen-fsgrpc library** to support `google.protobuf.Struct`, `google.protobuf.Value`, `google.protobuf.ListValue`, and `google.protobuf.NullValue` types.
+
+The code generator already has all the necessary capabilities to handle these types correctly.
+
+---
+
+## Defense of Position: No Changes Required
+
+### 1. The Code Already Handles All Message Types Generically
+
+**Evidence from `ProtoCodeGen.fs` (lines 157-177):**
+
+```fsharp
+static member From (typeMap: TypeMap) (proto: FieldDescriptorProto.Type) (typeName: string) =
+    match proto with
+    | ProtoFieldType.Double -> ValueType.Double
+    | ProtoFieldType.Float -> ValueType.Float
+    // ... other primitive types ...
+    | ProtoFieldType.Enum -> ValueType.Enum (typeMap typeName)
+    | ProtoFieldType.Message ->
+        match typeName with
+        | ".google.protobuf.DoubleValue" -> ValueType.Wrap ValueType.Double
+        | ".google.protobuf.FloatValue" -> ValueType.Wrap ValueType.Float
+        // ... other wrapper types ...
+        | ".google.protobuf.Timestamp" -> ValueType.Timestamp
+        | ".google.protobuf.Duration" -> ValueType.Duration
+        | ".google.protobuf.Any" -> ValueType.Any
+        | other -> ValueType.Message (typeMap other)  // <-- STRUCT TYPES GO HERE
+    | _ -> failwith $"Don't know how to handle type {proto}"
+```
+
+**Key Point**: The `| other -> ValueType.Message (typeMap other)` fallback case handles **any message type** not explicitly special-cased. Since Struct, Value, ListValue are just regular Protocol Buffer messages, they will be processed through this path without any special handling needed.
+
+### 2. Recursive Types Are Already Supported
+
+**Evidence from `ProtoCodeGen.fs` (line 1223):**
+
+```fsharp
+let private toFsNamespaceDecl (package: string) =
+    Frag [
+    Line $"namespace rec {toFsNamespace package}"  // <-- ALREADY USES "rec" KEYWORD
+    Line $"open FsGrpc.Protobuf"
+    Line $"open Google.Protobuf"
+    Line $"#nowarn \"40\""
+    Line $"#nowarn \"1182\""
+    ]
+```
+
+**Key Point**: The code generator **already generates `namespace rec`** for ALL generated namespaces, which is exactly what's needed for mutually recursive types like Struct and Value.
+
+### 3. Map Fields Are Already Supported
+
+**Evidence from `FieldType.From` function (lines 238-254):**
+
+```fsharp
+let fieldType = 
+    match (mapType, oneofOption, repeated, optional, message) with
+    | (Some mapType, _, _, _, _) ->
+        let k = mapType.Fields |> Seq.find (fun f -> f.Number = 1)
+        let v = mapType.Fields |> Seq.find (fun f -> f.Number = 2)
+        let keyTypeCode = k.Type
+        let keyTypeName = k.TypeName
+        let valTypeCode = v.Type
+        let valTypeName = v.TypeName
+        let keyType = ValueType.From typeMap keyTypeCode keyTypeName
+        let valType = ValueType.From typeMap valTypeCode valTypeName
+        FieldType.Map { Key = keyType; Value = valType }
+    // ... other cases ...
+```
+
+**Key Point**: The generator already knows how to process map fields and will generate `Map<string, Value>` for `Struct.fields` automatically.
+
+### 4. Oneof Fields Are Already Supported
+
+**Evidence from existing test reference in guide:**
+
+The guide itself references `gen/testproto.proto.gen.fs` showing that oneof types already work:
+
+```fsharp
+type UnionCase =
+| None
+| Color of Test.Name.Space.Enums.Color
+| Name of string
+```
+
+**Key Point**: The `Value.kind` oneof with 6 cases (including recursive `StructValue` and `ListValue` cases) will be generated using the existing oneof machinery.
+
+### 5. Lazy Evaluation for Circular Dependencies
+
+**Evidence from `toProtoDefImpl` and `toFsRecordDef`:**
+
+The generator already uses `Lazy<ProtoDef<T>>` for all Proto definitions:
+
+```fsharp
+static member Proto : Lazy<ProtoDef<{fsTypeName}>> =
+    lazy
+    // Field Definitions
+    // ...
+```
+
+**Key Point**: This lazy evaluation is already in place for ALL message types, which is exactly what's needed to handle the circular references between Struct and Value.
+
+---
+
+## Why Struct Types Might Not Have Been Generated Previously
+
+The issue is likely **NOT in protoc-gen-fsgrpc**, but rather in one of these areas:
+
+### Hypothesis 1: Input Files Not Provided
+- `struct.proto` wasn't included in the files passed to the code generator
+- The `--include-wkt` flag wasn't used, or wasn't working correctly with buf/protoc
+
+### Hypothesis 2: Generator Invocation Issue
+- The consuming project (FsGrpc) might not have been configured to generate code for `google/protobuf/struct.proto`
+- The `buf.gen.yaml` or equivalent configuration might not include struct.proto
+
+### Hypothesis 3: File Filtering
+- Some other part of the pipeline might be filtering out well-known types that aren't explicitly handled
+
+---
+
+## Testing Recommendations for FsGrpc (Consuming Library)
+
+### Step 1: Verify struct.proto Is Being Processed
+
+Run buf generate with verbose output:
+```sh
+cd FsGrpc.Tests
+buf generate --include-imports --include-wkt -v
+```
+
+Check if `google/protobuf/struct.proto` appears in the list of files being processed.
+
+### Step 2: Manually Test Code Generation
+
+Create a test proto file that uses Struct:
+
+**`test_struct.proto`:**
+```protobuf
+syntax = "proto3";
+package test;
+
+import "google/protobuf/struct.proto";
+
+message TestMessage {
+  google.protobuf.Struct metadata = 1;
+  google.protobuf.Value data = 2;
+  google.protobuf.ListValue items = 3;
+  google.protobuf.NullValue null_field = 4;
+}
+```
+
+Generate code for this file and verify:
+1. `google.protobuf.Struct` type is generated
+2. `google.protobuf.Value` type is generated
+3. `google.protobuf.ListValue` type is generated
+4. `google.protobuf.NullValue` enum is generated
+5. The generated code compiles
+6. The recursive references work correctly
+
+### Step 3: Check Generated Output
+
+After running buf generate, look for:
+```
+gen/google/protobuf/struct.proto.gen.fs
+```
+
+The file should contain:
+- `type NullValue = ...` (enum)
+- `module Value = ...` with nested `Kind` discriminated union
+- `type Value = { Kind: Value.Kind }` (record)
+- `module Struct = ...`
+- `type Struct = { Fields: Map<string, Value> }` (record)
+- `module ListValue = ...`
+- `type ListValue = { Values: Value list }` (record)
+
+### Step 4: Verify Build
+
+The generated code should compile without errors when building FsGrpc.Tests:
+```sh
+dotnet build FsGrpc.Tests.fsproj
+```
+
+### Step 5: Test Runtime Functionality
+
+Uncomment the tests in `FsGrpc.Tests/JsonTests.fs` (lines 680-720) and run:
+```sh
+dotnet test FsGrpc.Tests.fsproj
+```
+
+---
+
+## Expected Generated Code Structure
+
+Based on the existing code generator patterns, here's what **should** be automatically generated:
+
+```fsharp
+namespace rec Google.Protobuf
+open FsGrpc.Protobuf
+open Google.Protobuf
+#nowarn "40"
+#nowarn "1182"
+
+// ===== NullValue Enum =====
+
+[<System.Text.Json.Serialization.JsonConverter(typeof<FsGrpc.Json.EnumConverter<NullValue>>)>]
+type NullValue =
+| [<FsGrpc.Protobuf.ProtobufName("NULL_VALUE")>] NullValue = 0
+
+// ===== Value Type with Oneof =====
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module Value =
+    
+    [<System.Text.Json.Serialization.JsonConverter(typeof<FsGrpc.Json.OneofConverter<Kind>>)>]
+    [<CompilationRepresentation(CompilationRepresentationFlags.UseNullAsTrueValue)>]
+    [<StructuralEquality;StructuralComparison>]
+    [<RequireQualifiedAccess>]
+    type Kind =
+    | None
+    | [<System.Text.Json.Serialization.JsonPropertyName("nullValue")>] NullValue of Google.Protobuf.NullValue
+    | [<System.Text.Json.Serialization.JsonPropertyName("numberValue")>] NumberValue of double
+    | [<System.Text.Json.Serialization.JsonPropertyName("stringValue")>] StringValue of string
+    | [<System.Text.Json.Serialization.JsonPropertyName("boolValue")>] BoolValue of bool
+    | [<System.Text.Json.Serialization.JsonPropertyName("structValue")>] StructValue of Google.Protobuf.Struct
+    | [<System.Text.Json.Serialization.JsonPropertyName("listValue")>] ListValue of Google.Protobuf.ListValue
+    with
+        static member OneofCodec : Lazy<OneofCodec<Kind>> = 
+            lazy
+            // Auto-generated field codecs for each case
+            let NullValue = FieldCodec.OneofCase "kind" ValueCodec.Enum<Google.Protobuf.NullValue> (1, "nullValue")
+            let NumberValue = FieldCodec.OneofCase "kind" ValueCodec.Double (2, "numberValue")
+            let StringValue = FieldCodec.OneofCase "kind" ValueCodec.String (3, "stringValue")
+            let BoolValue = FieldCodec.OneofCase "kind" ValueCodec.Bool (4, "boolValue")
+            let StructValue = FieldCodec.OneofCase "kind" ValueCodec.Message<Google.Protobuf.Struct> (5, "structValue")
+            let ListValue = FieldCodec.OneofCase "kind" ValueCodec.Message<Google.Protobuf.ListValue> (6, "listValue")
+            FieldCodec.Oneof "kind" (FSharp.Collections.Map [
+                ("nullValue", fun node -> Kind.NullValue (NullValue.ReadJsonField node))
+                ("numberValue", fun node -> Kind.NumberValue (NumberValue.ReadJsonField node))
+                ("stringValue", fun node -> Kind.StringValue (StringValue.ReadJsonField node))
+                ("boolValue", fun node -> Kind.BoolValue (BoolValue.ReadJsonField node))
+                ("structValue", fun node -> Kind.StructValue (StructValue.ReadJsonField node))
+                ("listValue", fun node -> Kind.ListValue (ListValue.ReadJsonField node))
+            ])
+
+    [<System.Runtime.CompilerServices.IsByRefLike>]
+    type Builder =
+        struct
+            val mutable Kind: OptionBuilder<Kind>
+        end
+        with
+        member x.Put ((tag, reader): int * Reader) =
+            match tag with
+            | 1 -> x.Kind.Set (Kind.NullValue (ValueCodec.Enum<Google.Protobuf.NullValue>.ReadValue reader))
+            | 2 -> x.Kind.Set (Kind.NumberValue (ValueCodec.Double.ReadValue reader))
+            | 3 -> x.Kind.Set (Kind.StringValue (ValueCodec.String.ReadValue reader))
+            | 4 -> x.Kind.Set (Kind.BoolValue (ValueCodec.Bool.ReadValue reader))
+            | 5 -> x.Kind.Set (Kind.StructValue (ValueCodec.Message<Google.Protobuf.Struct>.ReadValue reader))
+            | 6 -> x.Kind.Set (Kind.ListValue (ValueCodec.Message<Google.Protobuf.ListValue>.ReadValue reader))
+            | _ -> reader.SkipLastField()
+        member x.Build : Google.Protobuf.Value = {
+            Kind = x.Kind.Build |> (Option.defaultValue Kind.None)
+        }
+
+type private _Value = Value
+[<System.Text.Json.Serialization.JsonConverter(typeof<FsGrpc.Json.MessageConverter>)>]
+[<FsGrpc.Protobuf.Message>]
+[<StructuralEquality;StructuralComparison>]
+type Value = {
+    Kind: Value.Kind
+}
+with
+    static member Proto : Lazy<ProtoDef<Value>> =
+        lazy
+        let Kind = Value.Kind.OneofCodec.Value
+        {
+            Name = "Value"
+            Empty = {
+                Kind = Kind.GetDefault()
+            }
+            Size = fun (m: Value) ->
+                0
+                + match m.Kind with
+                | Value.Kind.None -> 0
+                | Value.Kind.NullValue v -> (* field codec size calculation *)
+                | Value.Kind.NumberValue v -> (* field codec size calculation *)
+                | Value.Kind.StringValue v -> (* field codec size calculation *)
+                | Value.Kind.BoolValue v -> (* field codec size calculation *)
+                | Value.Kind.StructValue v -> (* field codec size calculation *)
+                | Value.Kind.ListValue v -> (* field codec size calculation *)
+            Encode = fun (w: Google.Protobuf.CodedOutputStream) (m: Value) ->
+                (match m.Kind with
+                | Value.Kind.None -> ()
+                | Value.Kind.NullValue v -> (* write field *)
+                | Value.Kind.NumberValue v -> (* write field *)
+                | Value.Kind.StringValue v -> (* write field *)
+                | Value.Kind.BoolValue v -> (* write field *)
+                | Value.Kind.StructValue v -> (* write field *)
+                | Value.Kind.ListValue v -> (* write field *)
+                )
+            Decode = fun (r: Google.Protobuf.CodedInputStream) ->
+                let mutable builder = new Value.Builder()
+                let mutable tag = 0
+                while read r &tag do
+                    builder.Put (tag, r)
+                builder.Build
+            EncodeJson = fun (o: JsonOptions) ->
+                (* JSON encoding logic *)
+            DecodeJson = fun (node: System.Text.Json.Nodes.JsonNode) ->
+                (* JSON decoding logic *)
+        }
+    static member empty
+        with get() = Google.Protobuf._Value.Proto.Value.Empty
+
+// ===== Struct Type with Map Field =====
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module Struct =
+
+    [<System.Runtime.CompilerServices.IsByRefLike>]
+    type Builder =
+        struct
+            val mutable Fields: MapBuilder<string, Value>
+        end
+        with
+        member x.Put ((tag, reader): int * Reader) =
+            match tag with
+            | 1 -> x.Fields.Add ((ValueCodec.MapRecord ValueCodec.String ValueCodec.Message<Google.Protobuf.Value>).ReadValue reader)
+            | _ -> reader.SkipLastField()
+        member x.Build : Google.Protobuf.Struct = {
+            Fields = x.Fields.Build
+        }
+
+type private _Struct = Struct
+[<System.Text.Json.Serialization.JsonConverter(typeof<FsGrpc.Json.MessageConverter>)>]
+[<FsGrpc.Protobuf.Message>]
+[<StructuralEquality;StructuralComparison>]
+type Struct = {
+    [<System.Text.Json.Serialization.JsonPropertyName("fields")>] Fields: Map<string, Value> // (1)
+}
+with
+    static member Proto : Lazy<ProtoDef<Struct>> =
+        lazy
+        let Fields = FieldCodec.Map ValueCodec.String ValueCodec.Message<Google.Protobuf.Value> (1, "fields")
+        {
+            Name = "Struct"
+            Empty = {
+                Fields = Fields.GetDefault()
+            }
+            Size = fun (m: Struct) ->
+                0
+                + Fields.CalcFieldSize m.Fields
+            Encode = fun (w: Google.Protobuf.CodedOutputStream) (m: Struct) ->
+                Fields.WriteField w m.Fields
+            Decode = fun (r: Google.Protobuf.CodedInputStream) ->
+                let mutable builder = new Struct.Builder()
+                let mutable tag = 0
+                while read r &tag do
+                    builder.Put (tag, r)
+                builder.Build
+            EncodeJson = fun (o: JsonOptions) ->
+                let writeFields = Fields.WriteJsonField o
+                let encode (w: System.Text.Json.Utf8JsonWriter) (m: Struct) =
+                    writeFields w m.Fields
+                encode
+            DecodeJson = fun (node: System.Text.Json.Nodes.JsonNode) ->
+                let update value (kvPair: System.Collections.Generic.KeyValuePair<string,System.Text.Json.Nodes.JsonNode>) : Struct =
+                    match kvPair.Key with
+                    | "fields" -> { value with Fields = Fields.ReadJsonField kvPair.Value }
+                    | _ -> value
+                Seq.fold update _Struct.empty (node.AsObject ())
+        }
+    static member empty
+        with get() = Google.Protobuf._Struct.Proto.Value.Empty
+
+// ===== ListValue Type with Repeated Field =====
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module ListValue =
+
+    [<System.Runtime.CompilerServices.IsByRefLike>]
+    type Builder =
+        struct
+            val mutable Values: RepeatedBuilder<Value>
+        end
+        with
+        member x.Put ((tag, reader): int * Reader) =
+            match tag with
+            | 1 -> x.Values.Add (ValueCodec.Message<Google.Protobuf.Value>.ReadValue reader)
+            | _ -> reader.SkipLastField()
+        member x.Build : Google.Protobuf.ListValue = {
+            Values = x.Values.Build
+        }
+
+type private _ListValue = ListValue
+[<System.Text.Json.Serialization.JsonConverter(typeof<FsGrpc.Json.MessageConverter>)>]
+[<FsGrpc.Protobuf.Message>]
+[<StructuralEquality;StructuralComparison>]
+type ListValue = {
+    [<System.Text.Json.Serialization.JsonPropertyName("values")>] Values: Value list // (1)
+}
+with
+    static member Proto : Lazy<ProtoDef<ListValue>> =
+        lazy
+        let Values = FieldCodec.Repeated ValueCodec.Message<Google.Protobuf.Value> (1, "values")
+        {
+            Name = "ListValue"
+            Empty = {
+                Values = Values.GetDefault()
+            }
+            Size = fun (m: ListValue) ->
+                0
+                + Values.CalcFieldSize m.Values
+            Encode = fun (w: Google.Protobuf.CodedOutputStream) (m: ListValue) ->
+                Values.WriteField w m.Values
+            Decode = fun (r: Google.Protobuf.CodedInputStream) ->
+                let mutable builder = new ListValue.Builder()
+                let mutable tag = 0
+                while read r &tag do
+                    builder.Put (tag, r)
+                builder.Build
+            EncodeJson = fun (o: JsonOptions) ->
+                let writeValues = Values.WriteJsonField o
+                let encode (w: System.Text.Json.Utf8JsonWriter) (m: ListValue) =
+                    writeValues w m.Values
+                encode
+            DecodeJson = fun (node: System.Text.Json.Nodes.JsonNode) ->
+                let update value (kvPair: System.Collections.Generic.KeyValuePair<string,System.Text.Json.Nodes.JsonNode>) : ListValue =
+                    match kvPair.Key with
+                    | "values" -> { value with Values = Values.ReadJsonField kvPair.Value }
+                    | _ -> value
+                Seq.fold update _ListValue.empty (node.AsObject ())
+        }
+    static member empty
+        with get() = Google.Protobuf._ListValue.Proto.Value.Empty
+```
+
+---
+
+## Key Capabilities Already Present in protoc-gen-fsgrpc
+
+### ? Capability Matrix
+
+| Feature Required | Present in Code Generator | Evidence |
+|-----------------|---------------------------|----------|
+| Generic message type handling | ? Yes | `ValueType.From` function, line 177: `\| other -> ValueType.Message (typeMap other)` |
+| Recursive type support (`namespace rec`) | ? Yes | `toFsNamespaceDecl` function, line 1224: `Line $"namespace rec {toFsNamespace package}"` |
+| Map field generation | ? Yes | `FieldType.From` function, lines 238-254 |
+| Oneof field generation | ? Yes | Existing patterns in `toOneofUnionDefs`, `toFsRecordFieldDef` |
+| Lazy evaluation for circular deps | ? Yes | All Proto definitions use `Lazy<ProtoDef<T>>` |
+| Enum generation | ? Yes | `toFsEnumDef` function |
+| Repeated field generation | ? Yes | `FieldType.Repeated` case handling |
+| Builder pattern for mutable fields | ? Yes | `toBuilderField`, `toBuilderPut`, `toBuilderInit` functions |
+
+---
+
+## Diagnostic Checklist for FsGrpc Repository
+
+When investigating why Struct types aren't being generated, check:
+
+### 1. ? Input File Configuration
+```sh
+# Check if struct.proto is in the input
+buf generate --include-imports --include-wkt -v 2>&1 | grep struct.proto
+```
+
+### 2. ? buf.gen.yaml Configuration
+Check that the configuration includes:
+```yaml
+version: v1
+plugins:
+  - name: fsgrpc
+    out: gen
+    opt:
+      - include_wkt=true  # Or however it's configured
+```
+
+### 3. ? Generated File Location
+```sh
+# Check if the file was generated
+ls -la gen/google/protobuf/struct.proto.gen.fs
+```
+
+### 4. ? protoc-gen-fsgrpc Version
+```sh
+# Ensure using the latest version
+dotnet tool list --global | grep protoc-gen-fsgrpc
+```
+
+### 5. ? Build Output
+```sh
+# Check build output for errors related to Struct types
+dotnet build FsGrpc.Tests.fsproj -v d | grep -i struct
+```
+
+---
+
+## Recommended Actions for FsGrpc Repository
+
+### Priority 1: Verify Input Files
+The most likely issue is that `struct.proto` is not being passed to the code generator. Verify by:
+
+1. Run `buf generate` with verbose logging
+2. Check if `google/protobuf/struct.proto` appears in the file list
+3. If not, adjust `buf.gen.yaml` or `buf.yaml` to include well-known types
+
+### Priority 2: Test with Simple Proto
+Create a minimal test case:
+
+**`test/struct_test.proto`:**
+```protobuf
+syntax = "proto3";
+package test;
+import "google/protobuf/struct.proto";
+
+message StructTest {
+  google.protobuf.Struct data = 1;
+}
+```
+
+Generate and verify the output includes both `StructTest` and `Struct` types.
+
+### Priority 3: Check protoc-gen-fsgrpc Invocation
+Ensure the generator is being invoked correctly:
+```sh
+# Manual test
+protoc --plugin=protoc-gen-fsgrpc=/path/to/protoc-gen-fsgrpc \
+       --fsgrpc_out=. \
+       --proto_path=. \
+       google/protobuf/struct.proto
+```
+
+---
+
+## Special JSON Serialization Considerations
+
+The Proto3 JSON specification defines special serialization for Struct types:
+
+- `Struct` ? Plain JSON object (not wrapped)
+- `Value` ? Unwrapped JSON value based on kind
+- `ListValue` ? Plain JSON array
+- `NullValue` ? JSON `null`
+
+**Note**: The initial generated code will use standard `MessageConverter` and `EnumConverter`. If JSON tests fail, custom converters may need to be added to the **FsGrpc runtime library**, not to protoc-gen-fsgrpc.
+
+Example custom converter locations (if needed):
+- `FsGrpc/Json.fs` - Add custom `StructConverter`, `ValueConverter`, `ListValueConverter`
+
+---
+
+## Test Cases to Verify Functionality
+
+### Basic Structure Tests
+```fsharp
+[<Fact>]
+let ``NullValue enum can be created`` () =
+    let nullVal = Google.Protobuf.NullValue.NullValue
+    Assert.Equal(0, int nullVal)
+
+[<Fact>]
+let ``Value with NumberValue can be created`` () =
+    let value = { Kind = Google.Protobuf.Value.Kind.NumberValue 42.0 }
+    match value.Kind with
+    | Google.Protobuf.Value.Kind.NumberValue n -> Assert.Equal(42.0, n)
+    | _ -> Assert.Fail("Expected NumberValue")
+
+[<Fact>]
+let ``Struct with empty fields can be created`` () =
+    let struct = Google.Protobuf.Struct.empty
+    Assert.Empty(struct.Fields)
+
+[<Fact>]
+let ``ListValue with empty values can be created`` () =
+    let listValue = Google.Protobuf.ListValue.empty
+    Assert.Empty(listValue.Values)
+```
+
+### Recursive Structure Tests
+```fsharp
+[<Fact>]
+let ``Value can contain Struct (recursive)`` () =
+    let innerStruct = Google.Protobuf.Struct.empty
+    let value = { Kind = Google.Protobuf.Value.Kind.StructValue innerStruct }
+    match value.Kind with
+    | Google.Protobuf.Value.Kind.StructValue s -> Assert.Equal(innerStruct, s)
+    | _ -> Assert.Fail("Expected StructValue")
+
+[<Fact>]
+let ``Struct can contain Value in map`` () =
+    let value = { Kind = Google.Protobuf.Value.Kind.StringValue "test" }
+    let struct = { Fields = Map.ofList [("key", value)] }
+    Assert.Single(struct.Fields) |> ignore
+```
+
+### Protobuf Wire Format Tests
+```fsharp
+[<Fact>]
+let ``Struct round-trips through protobuf encoding`` () =
+    let original = Google.Protobuf.Struct.empty
+    let encoded = FsGrpc.Protobuf.encode original
+    let decoded = FsGrpc.Protobuf.decode<Google.Protobuf.Struct> encoded
+    Assert.Equal(original, decoded)
+
+[<Fact>]
+let ``Value round-trips through protobuf encoding`` () =
+    let original = { Kind = Google.Protobuf.Value.Kind.NumberValue 123.45 }
+    let encoded = FsGrpc.Protobuf.encode original
+    let decoded = FsGrpc.Protobuf.decode<Google.Protobuf.Value> encoded
+    Assert.Equal(original, decoded)
+```
+
+### JSON Serialization Tests (May Require Custom Converters)
+```fsharp
+[<Fact>]
+let ``Struct with simple fields serializes to JSON`` () =
+    let structValue = Google.Protobuf.Struct.empty
+    let actual = JsonSerializer.Serialize(structValue, ignoreDefault)
+    let expected = """{}"""
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Value with string serializes to JSON`` () =
+    let value = { Kind = Google.Protobuf.Value.Kind.StringValue "hello" }
+    let actual = JsonSerializer.Serialize(value)
+    // Per Proto3 JSON spec, should serialize as unwrapped: "hello"
+    let expected = "\"hello\""
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``ListValue serializes to JSON array`` () =
+    let listValue = { Values = [
+        { Kind = Google.Protobuf.Value.Kind.NumberValue 1.0 }
+        { Kind = Google.Protobuf.Value.Kind.StringValue "two" }
+    ]}
+    let actual = JsonSerializer.Serialize(listValue)
+    // Per Proto3 JSON spec, should serialize as: [1.0, "two"]
+    let expected = """[1.0,"two"]"""
+    Assert.Equal(expected, actual)
+```
+
+---
+
+## Conclusion
+
+### Summary of Findings
+
+1. **protoc-gen-fsgrpc requires NO code changes** - All necessary capabilities are already present
+2. **The issue is in the FsGrpc repository** - Specifically in how code generation is configured/invoked
+3. **Testing focus** - Verify that `struct.proto` is being processed by the generator
+
+### Immediate Next Steps for FsGrpc Repository
+
+1. ? Run `buf generate --include-imports --include-wkt -v` and capture output
+2. ? Verify `google/protobuf/struct.proto` is in the processed file list
+3. ? Check for generated `gen/google/protobuf/struct.proto.gen.fs`
+4. ? If file exists, build the project and verify compilation
+5. ? If build succeeds, uncomment and run tests in `JsonTests.fs`
+6. ?? If JSON tests fail, add custom converters to FsGrpc runtime (not protoc-gen-fsgrpc)
+
+### Long-Term Recommendations
+
+1. Add integration tests in FsGrpc.Tests that specifically cover Struct/Value types
+2. Document the `--include-wkt` flag requirement in README
+3. Consider adding a CI check to verify well-known types are generated
+4. If JSON serialization doesn't match Proto3 spec, implement custom converters in `FsGrpc/Json.fs`
+
+---
+
+## References
+
+- **protoc-gen-fsgrpc repository**: https://github.com/dmgtech/FsGrpc.ProtocGenFsGrpc
+- **FsGrpc repository**: https://github.com/dmgtech/fsgrpc
+- **Proto3 JSON Specification**: https://protobuf.dev/programming-guides/proto3/#json
+- **google.protobuf.Struct Documentation**: https://protobuf.dev/reference/protobuf/google.protobuf/#struct
+
+---
+
+## Document Metadata
+
+- **Created**: 2024-12-XX
+- **Analysis Target**: protoc-gen-fsgrpc code generator
+- **Target Framework**: .NET 8.0
+- **Conclusion**: No code changes required in protoc-gen-fsgrpc
+- **Status**: Ready for testing in FsGrpc repository

--- a/STRUCT_SUPPORT_ANALYSIS.md
+++ b/STRUCT_SUPPORT_ANALYSIS.md
@@ -654,12 +654,12 @@ let ``ListValue serializes to JSON array`` () =
 
 ### Immediate Next Steps for FsGrpc Repository
 
-1. ? Run `buf generate --include-imports --include-wkt -v` and capture output
-2. ? Verify `google/protobuf/struct.proto` is in the processed file list
-3. ? Check for generated `gen/google/protobuf/struct.proto.gen.fs`
-4. ? If file exists, build the project and verify compilation
-5. ? If build succeeds, uncomment and run tests in `JsonTests.fs`
-6. ?? If JSON tests fail, add custom converters to FsGrpc runtime (not protoc-gen-fsgrpc)
+- [ ] Run `buf generate --include-imports --include-wkt -v` and capture output
+- [ ] Verify `google/protobuf/struct.proto` is in the processed file list
+- [ ] Check for generated `gen/google/protobuf/struct.proto.gen.fs`
+- [ ] If file exists, build the project and verify compilation
+- [ ] If build succeeds, uncomment and run tests in `JsonTests.fs`
+- [ ] If JSON tests fail, add custom converters to FsGrpc runtime (not protoc-gen-fsgrpc)
 
 ### Long-Term Recommendations
 

--- a/STRUCT_SUPPORT_ANALYSIS.md
+++ b/STRUCT_SUPPORT_ANALYSIS.md
@@ -681,7 +681,7 @@ let ``ListValue serializes to JSON array`` () =
 
 ## Document Metadata
 
-- **Created**: 2024-12-XX
+- **Created**: 2024-06-10
 - **Analysis Target**: protoc-gen-fsgrpc code generator
 - **Target Framework**: .NET 8.0
 - **Conclusion**: No code changes required in protoc-gen-fsgrpc

--- a/dotnet-install.ps1
+++ b/dotnet-install.ps1
@@ -1,0 +1,1573 @@
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+<#
+.SYNOPSIS
+    Installs dotnet cli
+.DESCRIPTION
+    Installs dotnet cli. If dotnet installation already exists in the given directory
+    it will update it only if the requested version differs from the one already installed.
+
+    Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:
+    - The SDK needs to be installed without user interaction and without admin rights.
+    - The SDK installation doesn't need to persist across multiple CI runs.
+    To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.
+
+.PARAMETER Channel
+    Default: LTS
+    Download from the Channel specified. Possible values:
+    - STS - the most recent Standard Term Support release
+    - LTS - the most recent Long Term Support release
+    - 2-part version in a format A.B - represents a specific release
+          examples: 2.0, 1.0
+    - 3-part version in a format A.B.Cxx - represents a specific SDK release
+          examples: 5.0.1xx, 5.0.2xx
+          Supported since 5.0 release
+    Warning: Value "Current" is deprecated for the Channel parameter. Use "STS" instead.
+    Note: The version parameter overrides the channel parameter when any version other than 'latest' is used.
+.PARAMETER Quality
+    Download the latest build of specified quality in the channel. The possible values are: daily, preview, GA.
+    Works only in combination with channel. Not applicable for STS and LTS channels and will be ignored if those channels are used. 
+    Supported since 5.0 release.
+    Note: The version parameter overrides the channel parameter when any version other than 'latest' is used, and therefore overrides the quality.     
+.PARAMETER Version
+    Default: latest
+    Represents a build version on specific channel. Possible values:
+    - latest - the latest build on specific channel
+    - 3-part version in a format A.B.C - represents specific version of build
+          examples: 2.0.0-preview2-006120, 1.1.0
+.PARAMETER Internal
+    Download internal builds. Requires providing credentials via -FeedCredential parameter.
+.PARAMETER FeedCredential
+    Token to access Azure feed. Used as a query string to append to the Azure feed.
+    This parameter typically is not specified.
+.PARAMETER InstallDir
+    Default: %LocalAppData%\Microsoft\dotnet
+    Path to where to install dotnet. Note that binaries will be placed directly in a given directory.
+.PARAMETER Architecture
+    Default: <auto> - this value represents currently running OS architecture
+    Architecture of dotnet binaries to be installed.
+    Possible values are: <auto>, amd64, x64, x86, arm64, arm
+.PARAMETER SharedRuntime
+    This parameter is obsolete and may be removed in a future version of this script.
+    The recommended alternative is '-Runtime dotnet'.
+    Installs just the shared runtime bits, not the entire SDK.
+.PARAMETER Runtime
+    Installs just a shared runtime, not the entire SDK.
+    Possible values:
+        - dotnet     - the Microsoft.NETCore.App shared runtime
+        - aspnetcore - the Microsoft.AspNetCore.App shared runtime
+        - windowsdesktop - the Microsoft.WindowsDesktop.App shared runtime
+.PARAMETER DryRun
+    If set it will not perform installation but instead display what command line to use to consistently install
+    currently requested version of dotnet cli. In example if you specify version 'latest' it will display a link
+    with specific version so that this command can be used deterministically in a build script.
+    It also displays binaries location if you prefer to install or download it yourself.
+.PARAMETER NoPath
+    By default this script will set environment variable PATH for the current process to the binaries folder inside installation folder.
+    If set it will display binaries location but not set any environment variable.
+.PARAMETER Verbose
+    Displays diagnostics information.
+.PARAMETER AzureFeed
+    Default: https://builds.dotnet.microsoft.com/dotnet
+    For internal use only.
+    Allows using a different storage to download SDK archives from.
+.PARAMETER UncachedFeed
+    For internal use only.
+    Allows using a different storage to download SDK archives from.
+.PARAMETER ProxyAddress
+    If set, the installer will use the proxy when making web requests
+.PARAMETER ProxyUseDefaultCredentials
+    Default: false
+    Use default credentials, when using proxy address.
+.PARAMETER ProxyBypassList
+    If set with ProxyAddress, will provide the list of comma separated urls that will bypass the proxy
+.PARAMETER SkipNonVersionedFiles
+    Default: false
+    Skips installing non-versioned files if they already exist, such as dotnet.exe.
+.PARAMETER JSonFile
+    Determines the SDK version from a user specified global.json file
+    Note: global.json must have a value for 'SDK:Version'
+.PARAMETER DownloadTimeout
+    Determines timeout duration in seconds for downloading of the SDK file
+    Default: 1200 seconds (20 minutes)
+.PARAMETER KeepZip
+    If set, downloaded file is kept
+.PARAMETER ZipPath
+    Use that path to store installer, generated by default
+.EXAMPLE
+    dotnet-install.ps1 -Version 7.0.401
+    Installs the .NET SDK version 7.0.401
+.EXAMPLE
+    dotnet-install.ps1 -Channel 8.0 -Quality GA
+    Installs the latest GA (general availability) version of the .NET 8.0 SDK
+#>
+[cmdletbinding()]
+param(
+    [string]$Channel = "LTS",
+    [string]$Quality,
+    [string]$Version = "Latest",
+    [switch]$Internal,
+    [string]$JSonFile,
+    [Alias('i')][string]$InstallDir = "<auto>",
+    [string]$Architecture = "<auto>",
+    [string]$Runtime,
+    [Obsolete("This parameter may be removed in a future version of this script. The recommended alternative is '-Runtime dotnet'.")]
+    [switch]$SharedRuntime,
+    [switch]$DryRun,
+    [switch]$NoPath,
+    [string]$AzureFeed,
+    [string]$UncachedFeed,
+    [string]$FeedCredential,
+    [string]$ProxyAddress,
+    [switch]$ProxyUseDefaultCredentials,
+    [string[]]$ProxyBypassList = @(),
+    [switch]$SkipNonVersionedFiles,
+    [int]$DownloadTimeout = 1200,
+    [switch]$KeepZip,
+    [string]$ZipPath = [System.IO.Path]::combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName()),
+    [switch]$Help
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+function Say($str) {
+    try {
+        Write-Host "dotnet-install: $str"
+    }
+    catch {
+        # Some platforms cannot utilize Write-Host (Azure Functions, for instance). Fall back to Write-Output
+        Write-Output "dotnet-install: $str"
+    }
+}
+
+function Say-Warning($str) {
+    try {
+        Write-Warning "dotnet-install: $str"
+    }
+    catch {
+        # Some platforms cannot utilize Write-Warning (Azure Functions, for instance). Fall back to Write-Output
+        Write-Output "dotnet-install: Warning: $str"
+    }
+}
+
+# Writes a line with error style settings.
+# Use this function to show a human-readable comment along with an exception.
+function Say-Error($str) {
+    try {
+        # Write-Error is quite verbose for the purpose of the function, let's write one line with error style settings.
+        $Host.UI.WriteErrorLine("dotnet-install: $str")
+    }
+    catch {
+        Write-Output "dotnet-install: Error: $str"
+    }
+}
+
+function Say-Verbose($str) {
+    try {
+        Write-Verbose "dotnet-install: $str"
+    }
+    catch {
+        # Some platforms cannot utilize Write-Verbose (Azure Functions, for instance). Fall back to Write-Output
+        Write-Output "dotnet-install: $str"
+    }
+}
+
+function Measure-Action($name, $block) {
+    $time = Measure-Command $block
+    $totalSeconds = $time.TotalSeconds
+    Say-Verbose "Action '$name' took $totalSeconds seconds"
+}
+
+function Get-Remote-File-Size($zipUri) {
+    try {
+        $response = Invoke-WebRequest -UseBasicParsing -Uri $zipUri -Method Head
+        $fileSize = $response.Headers["Content-Length"]
+        if ((![string]::IsNullOrEmpty($fileSize))) {
+            Say "Remote file $zipUri size is $fileSize bytes."
+        
+            return $fileSize
+        }
+    }
+    catch {
+        Say-Verbose "Content-Length header was not extracted for $zipUri."
+    }
+
+    return $null
+}
+
+function Say-Invocation($Invocation) {
+    $command = $Invocation.MyCommand;
+    $args = (($Invocation.BoundParameters.Keys | foreach { "-$_ `"$($Invocation.BoundParameters[$_])`"" }) -join " ")
+    Say-Verbose "$command $args"
+}
+
+function Invoke-With-Retry([ScriptBlock]$ScriptBlock, [System.Threading.CancellationToken]$cancellationToken = [System.Threading.CancellationToken]::None, [int]$MaxAttempts = 3, [int]$SecondsBetweenAttempts = 1) {
+    $Attempts = 0
+    $local:startTime = $(get-date)
+
+    while ($true) {
+        try {
+            return & $ScriptBlock
+        }
+        catch {
+            $Attempts++
+            if (($Attempts -lt $MaxAttempts) -and -not $cancellationToken.IsCancellationRequested) {
+                Start-Sleep $SecondsBetweenAttempts
+            }
+            else {
+                $local:elapsedTime = $(get-date) - $local:startTime
+                if (($local:elapsedTime.TotalSeconds - $DownloadTimeout) -gt 0 -and -not $cancellationToken.IsCancellationRequested) {
+                    throw New-Object System.TimeoutException("Failed to reach the server: connection timeout: default timeout is $DownloadTimeout second(s)");
+                }
+                throw;
+            }
+        }
+    }
+}
+
+function Get-Machine-Architecture() {
+    Say-Invocation $MyInvocation
+
+    # On PS x86, PROCESSOR_ARCHITECTURE reports x86 even on x64 systems.
+    # To get the correct architecture, we need to use PROCESSOR_ARCHITEW6432.
+    # PS x64 doesn't define this, so we fall back to PROCESSOR_ARCHITECTURE.
+    # Possible values: amd64, x64, x86, arm64, arm
+    if ( $ENV:PROCESSOR_ARCHITEW6432 -ne $null ) {
+        return $ENV:PROCESSOR_ARCHITEW6432
+    }
+
+    try {        
+        if ( ((Get-CimInstance -ClassName CIM_OperatingSystem).OSArchitecture) -like "ARM*") {
+            if ( [Environment]::Is64BitOperatingSystem ) {
+                return "arm64"
+            }  
+            return "arm"
+        }
+    }
+    catch {
+        # Machine doesn't support Get-CimInstance
+    }
+
+    return $ENV:PROCESSOR_ARCHITECTURE
+}
+
+function Get-CLIArchitecture-From-Architecture([string]$Architecture) {
+    Say-Invocation $MyInvocation
+
+    if ($Architecture -eq "<auto>") {
+        $Architecture = Get-Machine-Architecture
+    }
+
+    switch ($Architecture.ToLowerInvariant()) {
+        { ($_ -eq "amd64") -or ($_ -eq "x64") } { return "x64" }
+        { $_ -eq "x86" } { return "x86" }
+        { $_ -eq "arm" } { return "arm" }
+        { $_ -eq "arm64" } { return "arm64" }
+        default { throw "Architecture '$Architecture' not supported. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues" }
+    }
+}
+
+function ValidateFeedCredential([string] $FeedCredential) {
+    if ($Internal -and [string]::IsNullOrWhitespace($FeedCredential)) {
+        $message = "Provide credentials via -FeedCredential parameter."
+        if ($DryRun) {
+            Say-Warning "$message"
+        }
+        else {
+            throw "$message"
+        }
+    }
+    
+    #FeedCredential should start with "?", for it to be added to the end of the link.
+    #adding "?" at the beginning of the FeedCredential if needed.
+    if ((![string]::IsNullOrWhitespace($FeedCredential)) -and ($FeedCredential[0] -ne '?')) {
+        $FeedCredential = "?" + $FeedCredential
+    }
+
+    return $FeedCredential
+}
+function Get-NormalizedQuality([string]$Quality) {
+    Say-Invocation $MyInvocation
+
+    if ([string]::IsNullOrEmpty($Quality)) {
+        return ""
+    }
+
+    switch ($Quality) {
+        { @("daily", "preview") -contains $_ } { return $Quality.ToLowerInvariant() }
+        #ga quality is available without specifying quality, so normalizing it to empty
+        { $_ -eq "ga" } { return "" }
+        default { throw "'$Quality' is not a supported value for -Quality option. Supported values are: daily, preview, ga. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues." }
+    }
+}
+
+function Get-NormalizedChannel([string]$Channel) {
+    Say-Invocation $MyInvocation
+
+    if ([string]::IsNullOrEmpty($Channel)) {
+        return ""
+    }
+
+    if ($Channel.Contains("Current")) {
+        Say-Warning 'Value "Current" is deprecated for -Channel option. Use "STS" instead.'
+    }
+
+    if ($Channel.StartsWith('release/')) {
+        Say-Warning 'Using branch name with -Channel option is no longer supported with newer releases. Use -Quality option with a channel in X.Y format instead, such as "-Channel 5.0 -Quality Daily."'
+    }
+
+    switch ($Channel) {
+        { $_ -eq "lts" } { return "LTS" }
+        { $_ -eq "sts" } { return "STS" }
+        { $_ -eq "current" } { return "STS" }
+        default { return $Channel.ToLowerInvariant() }
+    }
+}
+
+function Get-NormalizedProduct([string]$Runtime) {
+    Say-Invocation $MyInvocation
+
+    switch ($Runtime) {
+        { $_ -eq "dotnet" } { return "dotnet-runtime" }
+        { $_ -eq "aspnetcore" } { return "aspnetcore-runtime" }
+        { $_ -eq "windowsdesktop" } { return "windowsdesktop-runtime" }
+        { [string]::IsNullOrEmpty($_) } { return "dotnet-sdk" }
+        default { throw "'$Runtime' is not a supported value for -Runtime option, supported values are: dotnet, aspnetcore, windowsdesktop. If you think this is a bug, report it at https://github.com/dotnet/install-scripts/issues." }
+    }
+}
+
+
+# The version text returned from the feeds is a 1-line or 2-line string:
+# For the SDK and the dotnet runtime (2 lines):
+# Line 1: # commit_hash
+# Line 2: # 4-part version
+# For the aspnetcore runtime (1 line):
+# Line 1: # 4-part version
+function Get-Version-From-LatestVersion-File-Content([string]$VersionText) {
+    Say-Invocation $MyInvocation
+
+    $Data = -split $VersionText
+
+    $VersionInfo = @{
+        CommitHash = $(if ($Data.Count -gt 1) { $Data[0] })
+        Version    = $Data[-1] # last line is always the version number.
+    }
+    return $VersionInfo
+}
+
+function Load-Assembly([string] $Assembly) {
+    try {
+        Add-Type -Assembly $Assembly | Out-Null
+    }
+    catch {
+        # On Nano Server, Powershell Core Edition is used.  Add-Type is unable to resolve base class assemblies because they are not GAC'd.
+        # Loading the base class assemblies is not unnecessary as the types will automatically get resolved.
+    }
+}
+
+function GetHTTPResponse([Uri] $Uri, [bool]$HeaderOnly, [bool]$DisableRedirect, [bool]$DisableFeedCredential) {
+    $cts = New-Object System.Threading.CancellationTokenSource
+
+    $downloadScript = {
+
+        $HttpClient = $null
+
+        try {
+            # HttpClient is used vs Invoke-WebRequest in order to support Nano Server which doesn't support the Invoke-WebRequest cmdlet.
+            Load-Assembly -Assembly System.Net.Http
+
+            if (-not $ProxyAddress) {
+                try {
+                    # Despite no proxy being explicitly specified, we may still be behind a default proxy
+                    $DefaultProxy = [System.Net.WebRequest]::DefaultWebProxy;
+                    if ($DefaultProxy -and (-not $DefaultProxy.IsBypassed($Uri))) {
+                        if ($null -ne $DefaultProxy.GetProxy($Uri)) {
+                            $ProxyAddress = $DefaultProxy.GetProxy($Uri).OriginalString
+                        }
+                        else {
+                            $ProxyAddress = $null
+                        }
+                        $ProxyUseDefaultCredentials = $true
+                    }
+                }
+                catch {
+                    # Eat the exception and move forward as the above code is an attempt
+                    #    at resolving the DefaultProxy that may not have been a problem.
+                    $ProxyAddress = $null
+                    Say-Verbose("Exception ignored: $_.Exception.Message - moving forward...")
+                }
+            }
+
+            $HttpClientHandler = New-Object System.Net.Http.HttpClientHandler
+            if ($ProxyAddress) {
+                $HttpClientHandler.Proxy = New-Object System.Net.WebProxy -Property @{
+                    Address               = $ProxyAddress;
+                    UseDefaultCredentials = $ProxyUseDefaultCredentials;
+                    BypassList            = $ProxyBypassList;
+                }
+            }       
+            if ($DisableRedirect) {
+                $HttpClientHandler.AllowAutoRedirect = $false
+            }
+            $HttpClient = New-Object System.Net.Http.HttpClient -ArgumentList $HttpClientHandler
+
+            # Default timeout for HttpClient is 100s.  For a 50 MB download this assumes 500 KB/s average, any less will time out
+            # Defaulting to 20 minutes allows it to work over much slower connections.
+            $HttpClient.Timeout = New-TimeSpan -Seconds $DownloadTimeout
+
+            if ($HeaderOnly) {
+                $completionOption = [System.Net.Http.HttpCompletionOption]::ResponseHeadersRead
+            }
+            else {
+                $completionOption = [System.Net.Http.HttpCompletionOption]::ResponseContentRead
+            }
+
+            if ($DisableFeedCredential) {
+                $UriWithCredential = $Uri
+            }
+            else {
+                $UriWithCredential = "${Uri}${FeedCredential}"
+            }
+
+            $Task = $HttpClient.GetAsync("$UriWithCredential", $completionOption).ConfigureAwait("false");
+            $Response = $Task.GetAwaiter().GetResult();
+
+            if (($null -eq $Response) -or ((-not $HeaderOnly) -and (-not ($Response.IsSuccessStatusCode)))) {
+                # The feed credential is potentially sensitive info. Do not log FeedCredential to console output.
+                $DownloadException = [System.Exception] "Unable to download $Uri."
+
+                if ($null -ne $Response) {
+                    $DownloadException.Data["StatusCode"] = [int] $Response.StatusCode
+                    $DownloadException.Data["ErrorMessage"] = "Unable to download $Uri. Returned HTTP status code: " + $DownloadException.Data["StatusCode"]
+
+                    if (404 -eq [int] $Response.StatusCode) {
+                        $cts.Cancel()
+                    }
+                }
+
+                throw $DownloadException
+            }
+
+            return $Response
+        }
+        catch [System.Net.Http.HttpRequestException] {
+            $DownloadException = [System.Exception] "Unable to download $Uri."
+
+            # Pick up the exception message and inner exceptions' messages if they exist
+            $CurrentException = $PSItem.Exception
+            $ErrorMsg = $CurrentException.Message + "`r`n"
+            while ($CurrentException.InnerException) {
+                $CurrentException = $CurrentException.InnerException
+                $ErrorMsg += $CurrentException.Message + "`r`n"
+            }
+
+            # Check if there is an issue concerning TLS.
+            if ($ErrorMsg -like "*SSL/TLS*") {
+                $ErrorMsg += "Ensure that TLS 1.2 or higher is enabled to use this script.`r`n"
+            }
+
+            $DownloadException.Data["ErrorMessage"] = $ErrorMsg
+            throw $DownloadException
+        }
+        finally {
+            if ($null -ne $HttpClient) {
+                $HttpClient.Dispose()
+            }
+        }
+    }
+
+    try {
+        return Invoke-With-Retry $downloadScript $cts.Token
+    }
+    finally {
+        if ($null -ne $cts) {
+            $cts.Dispose()
+        }
+    }
+}
+
+function Get-Version-From-LatestVersion-File([string]$AzureFeed, [string]$Channel) {
+    Say-Invocation $MyInvocation
+
+    $VersionFileUrl = $null
+    if ($Runtime -eq "dotnet") {
+        $VersionFileUrl = "$AzureFeed/Runtime/$Channel/latest.version"
+    }
+    elseif ($Runtime -eq "aspnetcore") {
+        $VersionFileUrl = "$AzureFeed/aspnetcore/Runtime/$Channel/latest.version"
+    }
+    elseif ($Runtime -eq "windowsdesktop") {
+        $VersionFileUrl = "$AzureFeed/WindowsDesktop/$Channel/latest.version"
+    }
+    elseif (-not $Runtime) {
+        $VersionFileUrl = "$AzureFeed/Sdk/$Channel/latest.version"
+    }
+    else {
+        throw "Invalid value for `$Runtime"
+    }
+
+    Say-Verbose "Constructed latest.version URL: $VersionFileUrl"
+
+    try {
+        $Response = GetHTTPResponse -Uri $VersionFileUrl
+    }
+    catch {
+        Say-Verbose "Failed to download latest.version file."
+        throw
+    }
+    $StringContent = $Response.Content.ReadAsStringAsync().Result
+
+    switch ($Response.Content.Headers.ContentType) {
+        { ($_ -eq "application/octet-stream") } { $VersionText = $StringContent }
+        { ($_ -eq "text/plain") } { $VersionText = $StringContent }
+        { ($_ -eq "text/plain; charset=UTF-8") } { $VersionText = $StringContent }
+        default { throw "``$Response.Content.Headers.ContentType`` is an unknown .version file content type." }
+    }
+
+    $VersionInfo = Get-Version-From-LatestVersion-File-Content $VersionText
+
+    return $VersionInfo
+}
+
+function Parse-Jsonfile-For-Version([string]$JSonFile) {
+    Say-Invocation $MyInvocation
+
+    If (-Not (Test-Path $JSonFile)) {
+        throw "Unable to find '$JSonFile'"
+    }
+    try {
+        $JSonContent = Get-Content($JSonFile) -Raw | ConvertFrom-Json | Select-Object -expand "sdk" -ErrorAction SilentlyContinue
+    }
+    catch {
+        Say-Error "Json file unreadable: '$JSonFile'"
+        throw
+    }
+    if ($JSonContent) {
+        try {
+            $JSonContent.PSObject.Properties | ForEach-Object {
+                $PropertyName = $_.Name
+                if ($PropertyName -eq "version") {
+                    $Version = $_.Value
+                    Say-Verbose "Version = $Version"
+                }
+            }
+        }
+        catch {
+            Say-Error "Unable to parse the SDK node in '$JSonFile'"
+            throw
+        }
+    }
+    else {
+        throw "Unable to find the SDK node in '$JSonFile'"
+    }
+    If ($Version -eq $null) {
+        throw "Unable to find the SDK:version node in '$JSonFile'"
+    }
+    return $Version
+}
+
+function Get-Specific-Version-From-Version([string]$AzureFeed, [string]$Channel, [string]$Version, [string]$JSonFile) {
+    Say-Invocation $MyInvocation
+
+    if (-not $JSonFile) {
+        if ($Version.ToLowerInvariant() -eq "latest") {
+            $LatestVersionInfo = Get-Version-From-LatestVersion-File -AzureFeed $AzureFeed -Channel $Channel
+            return $LatestVersionInfo.Version
+        }
+        else {
+            return $Version 
+        }
+    }
+    else {
+        return Parse-Jsonfile-For-Version $JSonFile
+    }
+}
+
+function Get-Download-Link([string]$AzureFeed, [string]$SpecificVersion, [string]$CLIArchitecture) {
+    Say-Invocation $MyInvocation
+
+    # If anything fails in this lookup it will default to $SpecificVersion
+    $SpecificProductVersion = Get-Product-Version -AzureFeed $AzureFeed -SpecificVersion $SpecificVersion
+
+    if ($Runtime -eq "dotnet") {
+        $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/dotnet-runtime-$SpecificProductVersion-win-$CLIArchitecture.zip"
+    }
+    elseif ($Runtime -eq "aspnetcore") {
+        $PayloadURL = "$AzureFeed/aspnetcore/Runtime/$SpecificVersion/aspnetcore-runtime-$SpecificProductVersion-win-$CLIArchitecture.zip"
+    }
+    elseif ($Runtime -eq "windowsdesktop") {
+        # The windows desktop runtime is part of the core runtime layout prior to 5.0
+        $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/windowsdesktop-runtime-$SpecificProductVersion-win-$CLIArchitecture.zip"
+        if ($SpecificVersion -match '^(\d+)\.(.*)$') {
+            $majorVersion = [int]$Matches[1]
+            if ($majorVersion -ge 5) {
+                $PayloadURL = "$AzureFeed/WindowsDesktop/$SpecificVersion/windowsdesktop-runtime-$SpecificProductVersion-win-$CLIArchitecture.zip"
+            }
+        }
+    }
+    elseif (-not $Runtime) {
+        $PayloadURL = "$AzureFeed/Sdk/$SpecificVersion/dotnet-sdk-$SpecificProductVersion-win-$CLIArchitecture.zip"
+    }
+    else {
+        throw "Invalid value for `$Runtime"
+    }
+
+    Say-Verbose "Constructed primary named payload URL: $PayloadURL"
+
+    return $PayloadURL, $SpecificProductVersion
+}
+
+function Get-LegacyDownload-Link([string]$AzureFeed, [string]$SpecificVersion, [string]$CLIArchitecture) {
+    Say-Invocation $MyInvocation
+
+    if (-not $Runtime) {
+        $PayloadURL = "$AzureFeed/Sdk/$SpecificVersion/dotnet-dev-win-$CLIArchitecture.$SpecificVersion.zip"
+    }
+    elseif ($Runtime -eq "dotnet") {
+        $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/dotnet-win-$CLIArchitecture.$SpecificVersion.zip"
+    }
+    else {
+        return $null
+    }
+
+    Say-Verbose "Constructed legacy named payload URL: $PayloadURL"
+
+    return $PayloadURL
+}
+
+function Get-Product-Version([string]$AzureFeed, [string]$SpecificVersion, [string]$PackageDownloadLink) {
+    Say-Invocation $MyInvocation
+
+    # Try to get the version number, using the productVersion.txt file located next to the installer file.
+    $ProductVersionTxtURLs = (Get-Product-Version-Url $AzureFeed $SpecificVersion $PackageDownloadLink -Flattened $true),
+                             (Get-Product-Version-Url $AzureFeed $SpecificVersion $PackageDownloadLink -Flattened $false)
+    
+    Foreach ($ProductVersionTxtURL in $ProductVersionTxtURLs) {
+        Say-Verbose "Checking for the existence of $ProductVersionTxtURL"
+
+        try {
+            $productVersionResponse = GetHTTPResponse($productVersionTxtUrl)
+
+            if ($productVersionResponse.StatusCode -eq 200) {
+                $productVersion = $productVersionResponse.Content.ReadAsStringAsync().Result.Trim()
+                if ($productVersion -ne $SpecificVersion) {
+                    Say "Using alternate version $productVersion found in $ProductVersionTxtURL"
+                }
+                return $productVersion
+            }
+            else {
+                Say-Verbose "Got StatusCode $($productVersionResponse.StatusCode) when trying to get productVersion.txt at $productVersionTxtUrl."
+            }
+        } 
+        catch {
+            Say-Verbose "Could not read productVersion.txt at $productVersionTxtUrl (Exception: '$($_.Exception.Message)'. )"
+        }
+    }
+
+    # Getting the version number with productVersion.txt has failed. Try parsing the download link for a version number.
+    if ([string]::IsNullOrEmpty($PackageDownloadLink)) {
+        Say-Verbose "Using the default value '$SpecificVersion' as the product version."
+        return $SpecificVersion
+    }
+
+    $productVersion = Get-ProductVersionFromDownloadLink $PackageDownloadLink $SpecificVersion
+    return $productVersion
+}
+
+function Get-Product-Version-Url([string]$AzureFeed, [string]$SpecificVersion, [string]$PackageDownloadLink, [bool]$Flattened) {
+    Say-Invocation $MyInvocation
+
+    $majorVersion = $null
+    if ($SpecificVersion -match '^(\d+)\.(.*)') {
+        $majorVersion = $Matches[1] -as [int]
+    }
+
+    $pvFileName = 'productVersion.txt'
+    if ($Flattened) {
+        if (-not $Runtime) {
+            $pvFileName = 'sdk-productVersion.txt'
+        }
+        elseif ($Runtime -eq "dotnet") {
+            $pvFileName = 'runtime-productVersion.txt'
+        }
+        else {
+            $pvFileName = "$Runtime-productVersion.txt"
+        }
+    }
+
+    if ([string]::IsNullOrEmpty($PackageDownloadLink)) {
+        if ($Runtime -eq "dotnet") {
+            $ProductVersionTxtURL = "$AzureFeed/Runtime/$SpecificVersion/$pvFileName"
+        }
+        elseif ($Runtime -eq "aspnetcore") {
+            $ProductVersionTxtURL = "$AzureFeed/aspnetcore/Runtime/$SpecificVersion/$pvFileName"
+        }
+        elseif ($Runtime -eq "windowsdesktop") {
+            # The windows desktop runtime is part of the core runtime layout prior to 5.0
+            $ProductVersionTxtURL = "$AzureFeed/Runtime/$SpecificVersion/$pvFileName"
+            if ($majorVersion -ne $null -and $majorVersion -ge 5) {
+                $ProductVersionTxtURL = "$AzureFeed/WindowsDesktop/$SpecificVersion/$pvFileName"
+            }
+        }
+        elseif (-not $Runtime) {
+            $ProductVersionTxtURL = "$AzureFeed/Sdk/$SpecificVersion/$pvFileName"
+        }
+        else {
+            throw "Invalid value '$Runtime' specified for `$Runtime"
+        }
+    }
+    else {
+        $ProductVersionTxtURL = $PackageDownloadLink.Substring(0, $PackageDownloadLink.LastIndexOf("/")) + "/$pvFileName"
+    }
+
+    Say-Verbose "Constructed productVersion link: $ProductVersionTxtURL"
+
+    return $ProductVersionTxtURL
+}
+
+function Get-ProductVersionFromDownloadLink([string]$PackageDownloadLink, [string]$SpecificVersion) {
+    Say-Invocation $MyInvocation
+
+    #product specific version follows the product name
+    #for filename 'dotnet-sdk-3.1.404-win-x64.zip': the product version is 3.1.400
+    $filename = $PackageDownloadLink.Substring($PackageDownloadLink.LastIndexOf("/") + 1)
+    $filenameParts = $filename.Split('-')
+    if ($filenameParts.Length -gt 2) {
+        $productVersion = $filenameParts[2]
+        Say-Verbose "Extracted product version '$productVersion' from download link '$PackageDownloadLink'."
+    }
+    else {
+        Say-Verbose "Using the default value '$SpecificVersion' as the product version."
+        $productVersion = $SpecificVersion
+    }
+    return $productVersion 
+}
+
+function Get-User-Share-Path() {
+    Say-Invocation $MyInvocation
+
+    $InstallRoot = $env:DOTNET_INSTALL_DIR
+    if (!$InstallRoot) {
+        $InstallRoot = "$env:LocalAppData\Microsoft\dotnet"
+    }
+    elseif ($InstallRoot -like "$env:ProgramFiles\dotnet\?*") {
+        Say-Warning "The install root specified by the environment variable DOTNET_INSTALL_DIR points to the sub folder of $env:ProgramFiles\dotnet which is the default dotnet install root using .NET SDK installer. It is better to keep aligned with .NET SDK installer."
+    }
+    return $InstallRoot
+}
+
+function Resolve-Installation-Path([string]$InstallDir) {
+    Say-Invocation $MyInvocation
+
+    if ($InstallDir -eq "<auto>") {
+        return Get-User-Share-Path
+    }
+    return $InstallDir
+}
+
+function Test-User-Write-Access([string]$InstallDir) {
+    try {
+        $tempFileName = [guid]::NewGuid().ToString()
+        $tempFilePath = Join-Path -Path $InstallDir -ChildPath $tempFileName
+        New-Item -Path $tempFilePath -ItemType File -Force
+        Remove-Item $tempFilePath -Force
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+
+function Is-Dotnet-Package-Installed([string]$InstallRoot, [string]$RelativePathToPackage, [string]$SpecificVersion) {
+    Say-Invocation $MyInvocation
+
+    $DotnetPackagePath = Join-Path -Path $InstallRoot -ChildPath $RelativePathToPackage | Join-Path -ChildPath $SpecificVersion
+    Say-Verbose "Is-Dotnet-Package-Installed: DotnetPackagePath=$DotnetPackagePath"
+    return Test-Path $DotnetPackagePath -PathType Container
+}
+
+function Get-Absolute-Path([string]$RelativeOrAbsolutePath) {
+    # Too much spam
+    # Say-Invocation $MyInvocation
+
+    return $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($RelativeOrAbsolutePath)
+}
+
+function Get-Path-Prefix-With-Version($path) {
+    # example path with regex: shared/1.0.0-beta-12345/somepath
+    $match = [regex]::match($path, "/\d+\.\d+[^/]+/")
+    if ($match.Success) {
+        return $entry.FullName.Substring(0, $match.Index + $match.Length)
+    }
+
+    return $null
+}
+
+function Get-List-Of-Directories-And-Versions-To-Unpack-From-Dotnet-Package([System.IO.Compression.ZipArchive]$Zip, [string]$OutPath) {
+    Say-Invocation $MyInvocation
+
+    $ret = @()
+    foreach ($entry in $Zip.Entries) {
+        $dir = Get-Path-Prefix-With-Version $entry.FullName
+        if ($null -ne $dir) {
+            $path = Get-Absolute-Path $(Join-Path -Path $OutPath -ChildPath $dir)
+            if (-Not (Test-Path $path -PathType Container)) {
+                $ret += $dir
+            }
+        }
+    }
+
+    $ret = $ret | Sort-Object | Get-Unique
+
+    $values = ($ret | foreach { "$_" }) -join ";"
+    Say-Verbose "Directories to unpack: $values"
+
+    return $ret
+}
+
+# Example zip content and extraction algorithm:
+# Rule: files if extracted are always being extracted to the same relative path locally
+# .\
+#       a.exe   # file does not exist locally, extract
+#       b.dll   # file exists locally, override only if $OverrideFiles set
+#       aaa\    # same rules as for files
+#           ...
+#       abc\1.0.0\  # directory contains version and exists locally
+#           ...     # do not extract content under versioned part
+#       abc\asd\    # same rules as for files
+#            ...
+#       def\ghi\1.0.1\  # directory contains version and does not exist locally
+#           ...         # extract content
+function Extract-Dotnet-Package([string]$ZipPath, [string]$OutPath) {
+    Say-Invocation $MyInvocation
+
+    Load-Assembly -Assembly System.IO.Compression.FileSystem
+    Set-Variable -Name Zip
+    try {
+        $Zip = [System.IO.Compression.ZipFile]::OpenRead($ZipPath)
+
+        $DirectoriesToUnpack = Get-List-Of-Directories-And-Versions-To-Unpack-From-Dotnet-Package -Zip $Zip -OutPath $OutPath
+
+        foreach ($entry in $Zip.Entries) {
+            $PathWithVersion = Get-Path-Prefix-With-Version $entry.FullName
+            if (($null -eq $PathWithVersion) -Or ($DirectoriesToUnpack -contains $PathWithVersion)) {
+                $DestinationPath = Get-Absolute-Path $(Join-Path -Path $OutPath -ChildPath $entry.FullName)
+                $DestinationDir = Split-Path -Parent $DestinationPath
+                $OverrideFiles = $OverrideNonVersionedFiles -Or (-Not (Test-Path $DestinationPath))
+                if ((-Not $DestinationPath.EndsWith("\")) -And $OverrideFiles) {
+                    New-Item -ItemType Directory -Force -Path $DestinationDir | Out-Null
+                    [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $DestinationPath, $OverrideNonVersionedFiles)
+                }
+            }
+        }
+    }
+    catch {
+        Say-Error "Failed to extract package. Exception: $_"
+        throw;
+    }
+    finally {
+        if ($null -ne $Zip) {
+            $Zip.Dispose()
+        }
+    }
+}
+
+function DownloadFile($Source, [string]$OutPath) {
+    if ($Source -notlike "http*") {
+        #  Using System.IO.Path.GetFullPath to get the current directory
+        #    does not work in this context - $pwd gives the current directory
+        if (![System.IO.Path]::IsPathRooted($Source)) {
+            $Source = $(Join-Path -Path $pwd -ChildPath $Source)
+        }
+        $Source = Get-Absolute-Path $Source
+        Say "Copying file from $Source to $OutPath"
+        Copy-Item $Source $OutPath
+        return
+    }
+
+    $Stream = $null
+    
+    try {
+        $Response = GetHTTPResponse -Uri $Source
+        $Stream = $Response.Content.ReadAsStreamAsync().Result
+        $File = [System.IO.File]::Create($OutPath)
+        $Stream.CopyTo($File)
+        $File.Close()
+
+        ValidateRemoteLocalFileSizes -LocalFileOutPath $OutPath -SourceUri $Source
+    }
+    finally {
+        if ($null -ne $Stream) {
+            $Stream.Dispose()
+        }
+    }
+}
+
+function ValidateRemoteLocalFileSizes([string]$LocalFileOutPath, $SourceUri) {
+    try {
+        $remoteFileSize = Get-Remote-File-Size -zipUri $SourceUri
+        $fileSize = [long](Get-Item $LocalFileOutPath).Length
+        Say "Downloaded file $SourceUri size is $fileSize bytes."
+    
+        if ((![string]::IsNullOrEmpty($remoteFileSize)) -and !([string]::IsNullOrEmpty($fileSize)) ) {
+            if ($remoteFileSize -ne $fileSize) {
+                Say "The remote and local file sizes are not equal. Remote file size is $remoteFileSize bytes and local size is $fileSize bytes. The local package may be corrupted."
+            }
+            else {
+                Say "The remote and local file sizes are equal."
+            }   
+        }
+        else {
+            Say "Either downloaded or local package size can not be measured. One of them may be corrupted."
+        }
+    }
+    catch {
+        Say "Either downloaded or local package size can not be measured. One of them may be corrupted."
+    }
+}
+
+function SafeRemoveFile($Path) {
+    try {
+        if (Test-Path $Path) {
+            Remove-Item $Path
+            Say-Verbose "The temporary file `"$Path`" was removed."
+        }
+        else {
+            Say-Verbose "The temporary file `"$Path`" does not exist, therefore is not removed."
+        }
+    }
+    catch {
+        Say-Warning "Failed to remove the temporary file: `"$Path`", remove it manually."
+    }
+}
+
+function Prepend-Sdk-InstallRoot-To-Path([string]$InstallRoot) {
+    $BinPath = Get-Absolute-Path $(Join-Path -Path $InstallRoot -ChildPath "")
+    if (-Not $NoPath) {
+        $SuffixedBinPath = "$BinPath;"
+        if (-Not $env:path.Contains($SuffixedBinPath)) {
+            Say "Adding to current process PATH: `"$BinPath`". Note: This change will not be visible if PowerShell was run as a child process."
+            $env:path = $SuffixedBinPath + $env:path
+        }
+        else {
+            Say-Verbose "Current process PATH already contains `"$BinPath`""
+        }
+    }
+    else {
+        Say "Binaries of dotnet can be found in $BinPath"
+    }
+}
+
+function PrintDryRunOutput($Invocation, $DownloadLinks) {
+    Say "Payload URLs:"
+    
+    for ($linkIndex = 0; $linkIndex -lt $DownloadLinks.count; $linkIndex++) {
+        Say "URL #$linkIndex - $($DownloadLinks[$linkIndex].type): $($DownloadLinks[$linkIndex].downloadLink)"
+    }
+    $RepeatableCommand = ".\$ScriptName -Version `"$SpecificVersion`" -InstallDir `"$InstallRoot`" -Architecture `"$CLIArchitecture`""
+    if ($Runtime -eq "dotnet") {
+        $RepeatableCommand += " -Runtime `"dotnet`""
+    }
+    elseif ($Runtime -eq "aspnetcore") {
+        $RepeatableCommand += " -Runtime `"aspnetcore`""
+    }
+
+    foreach ($key in $Invocation.BoundParameters.Keys) {
+        if (-not (@("Architecture", "Channel", "DryRun", "InstallDir", "Runtime", "SharedRuntime", "Version", "Quality", "FeedCredential") -contains $key)) {
+            $RepeatableCommand += " -$key `"$($Invocation.BoundParameters[$key])`""
+        }
+    }
+    if ($Invocation.BoundParameters.Keys -contains "FeedCredential") {
+        $RepeatableCommand += " -FeedCredential `"<feedCredential>`""
+    }
+    Say "Repeatable invocation: $RepeatableCommand"
+    if ($SpecificVersion -ne $EffectiveVersion) {
+        Say "NOTE: Due to finding a version manifest with this runtime, it would actually install with version '$EffectiveVersion'"
+    }
+}
+
+function Get-AkaMSDownloadLink([string]$Channel, [string]$Quality, [bool]$Internal, [string]$Product, [string]$Architecture) {
+    Say-Invocation $MyInvocation 
+
+    #quality is not supported for LTS or STS channel
+    if (![string]::IsNullOrEmpty($Quality) -and (@("LTS", "STS") -contains $Channel)) {
+        $Quality = ""
+        Say-Warning "Specifying quality for STS or LTS channel is not supported, the quality will be ignored."
+    }
+    Say-Verbose "Retrieving primary payload URL from aka.ms link for channel: '$Channel', quality: '$Quality' product: '$Product', os: 'win', architecture: '$Architecture'." 
+   
+    #construct aka.ms link
+    $akaMsLink = "https://aka.ms/dotnet"
+    if ($Internal) {
+        $akaMsLink += "/internal"
+    }
+    $akaMsLink += "/$Channel"
+    if (-not [string]::IsNullOrEmpty($Quality)) {
+        $akaMsLink += "/$Quality"
+    }
+    $akaMsLink += "/$Product-win-$Architecture.zip"
+    Say-Verbose  "Constructed aka.ms link: '$akaMsLink'."
+    $akaMsDownloadLink = $null
+
+    for ($maxRedirections = 9; $maxRedirections -ge 0; $maxRedirections--) {
+        #get HTTP response
+        #do not pass credentials as a part of the $akaMsLink and do not apply credentials in the GetHTTPResponse function
+        #otherwise the redirect link would have credentials as well
+        #it would result in applying credentials twice to the resulting link and thus breaking it, and in echoing credentials to the output as a part of redirect link
+        $Response = GetHTTPResponse -Uri $akaMsLink -HeaderOnly $true -DisableRedirect $true -DisableFeedCredential $true
+        Say-Verbose "Received response:`n$Response"
+
+        if ([string]::IsNullOrEmpty($Response)) {
+            Say-Verbose "The link '$akaMsLink' is not valid: failed to get redirect location. The resource is not available."
+            return $null
+        }
+
+        #if HTTP code is 301 (Moved Permanently), the redirect link exists
+        if ($Response.StatusCode -eq 301) {
+            try {
+                $akaMsDownloadLink = $Response.Headers.GetValues("Location")[0]
+
+                if ([string]::IsNullOrEmpty($akaMsDownloadLink)) {
+                    Say-Verbose "The link '$akaMsLink' is not valid: server returned 301 (Moved Permanently), but the headers do not contain the redirect location."
+                    return $null
+                }
+
+                Say-Verbose "The redirect location retrieved: '$akaMsDownloadLink'."
+                # This may yet be a link to another redirection. Attempt to retrieve the page again.
+                $akaMsLink = $akaMsDownloadLink
+                continue
+            }
+            catch {
+                Say-Verbose "The link '$akaMsLink' is not valid: failed to get redirect location."
+                return $null
+            }
+        }
+        elseif ((($Response.StatusCode -lt 300) -or ($Response.StatusCode -ge 400)) -and (-not [string]::IsNullOrEmpty($akaMsDownloadLink))) {
+            # Redirections have ended.
+            return $akaMsDownloadLink
+        }
+
+        Say-Verbose "The link '$akaMsLink' is not valid: failed to retrieve the redirection location."
+        return $null
+    }
+
+    Say-Verbose "Aka.ms links have redirected more than the maximum allowed redirections. This may be caused by a cyclic redirection of aka.ms links."
+    return $null
+
+}
+
+function Get-AkaMsLink-And-Version([string] $NormalizedChannel, [string] $NormalizedQuality, [bool] $Internal, [string] $ProductName, [string] $Architecture) {
+    $AkaMsDownloadLink = Get-AkaMSDownloadLink -Channel $NormalizedChannel -Quality $NormalizedQuality -Internal $Internal -Product $ProductName -Architecture $Architecture
+   
+    if ([string]::IsNullOrEmpty($AkaMsDownloadLink)) {
+        if (-not [string]::IsNullOrEmpty($NormalizedQuality)) {
+            # if quality is specified - exit with error - there is no fallback approach
+            Say-Error "Failed to locate the latest version in the channel '$NormalizedChannel' with '$NormalizedQuality' quality for '$ProductName', os: 'win', architecture: '$Architecture'."
+            Say-Error "Refer to: https://aka.ms/dotnet-os-lifecycle for information on .NET Core support."
+            throw "aka.ms link resolution failure"
+        }
+        Say-Verbose "Falling back to latest.version file approach."
+        return ($null, $null, $null)
+    }
+    else {
+        Say-Verbose "Retrieved primary named payload URL from aka.ms link: '$AkaMsDownloadLink'."
+        Say-Verbose  "Downloading using legacy url will not be attempted."
+
+        #get version from the path
+        $pathParts = $AkaMsDownloadLink.Split('/')
+        if ($pathParts.Length -ge 2) { 
+            $SpecificVersion = $pathParts[$pathParts.Length - 2]
+            Say-Verbose "Version: '$SpecificVersion'."
+        }
+        else {
+            Say-Error "Failed to extract the version from download link '$AkaMsDownloadLink'."
+            return ($null, $null, $null)
+        }
+
+        #retrieve effective (product) version
+        $EffectiveVersion = Get-Product-Version -SpecificVersion $SpecificVersion -PackageDownloadLink $AkaMsDownloadLink
+        Say-Verbose "Product version: '$EffectiveVersion'."
+
+        return ($AkaMsDownloadLink, $SpecificVersion, $EffectiveVersion);
+    }
+}
+
+function Get-Feeds-To-Use() {
+    $feeds = @(
+        "https://builds.dotnet.microsoft.com/dotnet"
+        "https://ci.dot.net/public"
+    )
+
+    if (-not [string]::IsNullOrEmpty($AzureFeed)) {
+        $feeds = @($AzureFeed)
+    }
+
+    if (-not [string]::IsNullOrEmpty($UncachedFeed)) {
+            $feeds = @($UncachedFeed)
+    }
+
+    Write-Verbose "Initialized feeds: $feeds"
+
+    return $feeds
+}
+
+function Resolve-AssetName-And-RelativePath([string] $Runtime) {
+    
+    if ($Runtime -eq "dotnet") {
+        $assetName = ".NET Core Runtime"
+        $dotnetPackageRelativePath = "shared\Microsoft.NETCore.App"
+    }
+    elseif ($Runtime -eq "aspnetcore") {
+        $assetName = "ASP.NET Core Runtime"
+        $dotnetPackageRelativePath = "shared\Microsoft.AspNetCore.App"
+    }
+    elseif ($Runtime -eq "windowsdesktop") {
+        $assetName = ".NET Core Windows Desktop Runtime"
+        $dotnetPackageRelativePath = "shared\Microsoft.WindowsDesktop.App"
+    }
+    elseif (-not $Runtime) {
+        $assetName = ".NET Core SDK"
+        $dotnetPackageRelativePath = "sdk"
+    }
+    else {
+        throw "Invalid value for `$Runtime"
+    }
+
+    return ($assetName, $dotnetPackageRelativePath)
+}
+
+function Prepare-Install-Directory {
+    $diskSpaceWarning = "Failed to check the disk space. Installation will continue, but it may fail if you do not have enough disk space.";
+
+    if ($PSVersionTable.PSVersion.Major -lt 7) {
+        Say-Verbose $diskSpaceWarning
+        return
+    }
+
+    New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
+
+    $installDrive = $((Get-Item $InstallRoot -Force).PSDrive.Name);
+    $diskInfo = $null
+    try {
+        $diskInfo = Get-PSDrive -Name $installDrive
+    }
+    catch {
+        Say-Warning $diskSpaceWarning
+    }
+
+    # The check is relevant for PS version >= 7, the result can be irrelevant for older versions. See https://github.com/PowerShell/PowerShell/issues/12442.
+    if ( ($null -ne $diskInfo) -and ($diskInfo.Free / 1MB -le 100)) {
+        throw "There is not enough disk space on drive ${installDrive}:"
+    }
+}
+
+if ($Help) {
+    Get-Help $PSCommandPath -Examples
+    exit
+}
+
+Say-Verbose "Note that the intended use of this script is for Continuous Integration (CI) scenarios, where:"
+Say-Verbose "- The SDK needs to be installed without user interaction and without admin rights."
+Say-Verbose "- The SDK installation doesn't need to persist across multiple CI runs."
+Say-Verbose "To set up a development environment or to run apps, use installers rather than this script. Visit https://dotnet.microsoft.com/download to get the installer.`r`n"
+
+if ($SharedRuntime -and (-not $Runtime)) {
+    $Runtime = "dotnet"
+}
+
+$OverrideNonVersionedFiles = !$SkipNonVersionedFiles
+
+Measure-Action "Product discovery" {
+    $script:CLIArchitecture = Get-CLIArchitecture-From-Architecture $Architecture
+    $script:NormalizedQuality = Get-NormalizedQuality $Quality
+    Say-Verbose "Normalized quality: '$NormalizedQuality'"
+    $script:NormalizedChannel = Get-NormalizedChannel $Channel
+    Say-Verbose "Normalized channel: '$NormalizedChannel'"
+    $script:NormalizedProduct = Get-NormalizedProduct $Runtime
+    Say-Verbose "Normalized product: '$NormalizedProduct'"
+    $script:FeedCredential = ValidateFeedCredential $FeedCredential
+}
+
+$InstallRoot = Resolve-Installation-Path $InstallDir
+if (-not (Test-User-Write-Access $InstallRoot)) {
+    Say-Error "The current user doesn't have write access to the installation root '$InstallRoot' to install .NET. Please try specifying a different installation directory using the -InstallDir parameter, or ensure the selected directory has the appropriate permissions."
+    throw
+}
+Say-Verbose "InstallRoot: $InstallRoot"
+$ScriptName = $MyInvocation.MyCommand.Name
+($assetName, $dotnetPackageRelativePath) = Resolve-AssetName-And-RelativePath -Runtime $Runtime
+
+$feeds = Get-Feeds-To-Use
+$DownloadLinks = @()
+
+if ($Version.ToLowerInvariant() -ne "latest" -and -not [string]::IsNullOrEmpty($Quality)) {
+    throw "Quality and Version options are not allowed to be specified simultaneously. See https:// learn.microsoft.com/dotnet/core/tools/dotnet-install-script#options for details."
+}
+
+# aka.ms links can only be used if the user did not request a specific version via the command line or a global.json file.
+if ([string]::IsNullOrEmpty($JSonFile) -and ($Version -eq "latest")) {
+    ($DownloadLink, $SpecificVersion, $EffectiveVersion) = Get-AkaMsLink-And-Version $NormalizedChannel $NormalizedQuality $Internal $NormalizedProduct $CLIArchitecture
+    
+    if ($null -ne $DownloadLink) {
+        $DownloadLinks += New-Object PSObject -Property @{downloadLink = "$DownloadLink"; specificVersion = "$SpecificVersion"; effectiveVersion = "$EffectiveVersion"; type = 'aka.ms' }
+        Say-Verbose "Generated aka.ms link $DownloadLink with version $EffectiveVersion"
+        
+        if (-Not $DryRun) {
+            Say-Verbose "Checking if the version $EffectiveVersion is already installed"
+            if (Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $EffectiveVersion) {
+                Say "$assetName with version '$EffectiveVersion' is already installed."
+                Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot
+                return
+            }
+        }
+    }
+}
+
+# Primary and legacy links cannot be used if a quality was specified.
+# If we already have an aka.ms link, no need to search the blob feeds.
+if ([string]::IsNullOrEmpty($NormalizedQuality) -and 0 -eq $DownloadLinks.count) {
+    foreach ($feed in $feeds) {
+        try {
+            $SpecificVersion = Get-Specific-Version-From-Version -AzureFeed $feed -Channel $Channel -Version $Version -JSonFile $JSonFile
+            $DownloadLink, $EffectiveVersion = Get-Download-Link -AzureFeed $feed -SpecificVersion $SpecificVersion -CLIArchitecture $CLIArchitecture
+            $LegacyDownloadLink = Get-LegacyDownload-Link -AzureFeed $feed -SpecificVersion $SpecificVersion -CLIArchitecture $CLIArchitecture
+            
+            $DownloadLinks += New-Object PSObject -Property @{downloadLink = "$DownloadLink"; specificVersion = "$SpecificVersion"; effectiveVersion = "$EffectiveVersion"; type = 'primary' }
+            Say-Verbose "Generated primary link $DownloadLink with version $EffectiveVersion"
+    
+            if (-not [string]::IsNullOrEmpty($LegacyDownloadLink)) {
+                $DownloadLinks += New-Object PSObject -Property @{downloadLink = "$LegacyDownloadLink"; specificVersion = "$SpecificVersion"; effectiveVersion = "$EffectiveVersion"; type = 'legacy' }
+                Say-Verbose "Generated legacy link $LegacyDownloadLink with version $EffectiveVersion"
+            }
+    
+            if (-Not $DryRun) {
+                Say-Verbose "Checking if the version $EffectiveVersion is already installed"
+                if (Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $EffectiveVersion) {
+                    Say "$assetName with version '$EffectiveVersion' is already installed."
+                    Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot
+                    return
+                }
+            }
+        }
+        catch {
+            Say-Verbose "Failed to acquire download links from feed $feed. Exception: $_"
+        }
+    }
+}
+
+if ($DownloadLinks.count -eq 0) {
+    throw "Failed to resolve the exact version number."
+}
+
+if ($DryRun) {
+    PrintDryRunOutput $MyInvocation $DownloadLinks
+    return
+}
+
+Measure-Action "Installation directory preparation" { Prepare-Install-Directory }
+
+Say-Verbose "Zip path: $ZipPath"
+
+$DownloadSucceeded = $false
+$DownloadedLink = $null
+$ErrorMessages = @()
+
+foreach ($link in $DownloadLinks) {
+    Say-Verbose "Downloading `"$($link.type)`" link $($link.downloadLink)"
+
+    try {
+        Measure-Action "Package download" { DownloadFile -Source $link.downloadLink -OutPath $ZipPath }
+        Say-Verbose "Download succeeded."
+        $DownloadSucceeded = $true
+        $DownloadedLink = $link
+        break
+    }
+    catch {
+        $StatusCode = $null
+        $ErrorMessage = $null
+
+        if ($PSItem.Exception.Data.Contains("StatusCode")) {
+            $StatusCode = $PSItem.Exception.Data["StatusCode"]
+        }
+    
+        if ($PSItem.Exception.Data.Contains("ErrorMessage")) {
+            $ErrorMessage = $PSItem.Exception.Data["ErrorMessage"]
+        }
+        else {
+            $ErrorMessage = $PSItem.Exception.Message
+        }
+
+        Say-Verbose "Download failed with status code $StatusCode. Error message: $ErrorMessage"
+        $ErrorMessages += "Downloading from `"$($link.type)`" link has failed with error:`nUri: $($link.downloadLink)`nStatusCode: $StatusCode`nError: $ErrorMessage"
+    }
+
+    # This link failed. Clean up before trying the next one.
+    SafeRemoveFile -Path $ZipPath
+}
+
+if (-not $DownloadSucceeded) {
+    foreach ($ErrorMessage in $ErrorMessages) {
+        Say-Error $ErrorMessages
+    }
+
+    throw "Could not find `"$assetName`" with version = $($DownloadLinks[0].effectiveVersion)`nRefer to: https://aka.ms/dotnet-os-lifecycle for information on .NET support"
+}
+
+Say "Extracting the archive."
+Measure-Action "Package extraction" { Extract-Dotnet-Package -ZipPath $ZipPath -OutPath $InstallRoot }
+
+#  Check if the SDK version is installed; if not, fail the installation.
+$isAssetInstalled = $false
+
+# if the version contains "RTM" or "servicing"; check if a 'release-type' SDK version is installed.
+if ($DownloadedLink.effectiveVersion -Match "rtm" -or $DownloadedLink.effectiveVersion -Match "servicing") {
+    $ReleaseVersion = $DownloadedLink.effectiveVersion.Split("-")[0]
+    Say-Verbose "Checking installation: version = $ReleaseVersion"
+    $isAssetInstalled = Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $ReleaseVersion
+}
+
+#  Check if the SDK version is installed.
+if (!$isAssetInstalled) {
+    Say-Verbose "Checking installation: version = $($DownloadedLink.effectiveVersion)"
+    $isAssetInstalled = Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $DownloadedLink.effectiveVersion
+}
+
+# Version verification failed. More likely something is wrong either with the downloaded content or with the verification algorithm.
+if (!$isAssetInstalled) {
+    Say-Error "Failed to verify the version of installed `"$assetName`".`nInstallation source: $($DownloadedLink.downloadLink).`nInstallation location: $InstallRoot.`nReport the bug at https://github.com/dotnet/install-scripts/issues."
+    throw "`"$assetName`" with version = $($DownloadedLink.effectiveVersion) failed to install with an unknown error."
+}
+
+if (-not $KeepZip) {
+    SafeRemoveFile -Path $ZipPath
+}
+
+Measure-Action "Setting up shell environment" { Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot }
+
+Say "Note that the script does not ensure your Windows version is supported during the installation."
+Say "To check the list of supported versions, go to https://learn.microsoft.com/dotnet/core/install/windows#supported-versions"
+Say "Installed version is $($DownloadedLink.effectiveVersion)"
+Say "Installation finished"
+
+# SIG # Begin signature block
+# MIIoKgYJKoZIhvcNAQcCoIIoGzCCKBcCAQExDzANBglghkgBZQMEAgEFADB5Bgor
+# BgEEAYI3AgEEoGswaTA0BgorBgEEAYI3AgEeMCYCAwEAAAQQH8w7YFlLCE63JNLG
+# KX7zUQIBAAIBAAIBAAIBAAIBADAxMA0GCWCGSAFlAwQCAQUABCCyKn7B6ieM6Y2C
+# rr9TCFvTSv2mMIh9mBGXh4z2gOksEqCCDXYwggX0MIID3KADAgECAhMzAAAEhV6Z
+# 7A5ZL83XAAAAAASFMA0GCSqGSIb3DQEBCwUAMH4xCzAJBgNVBAYTAlVTMRMwEQYD
+# VQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNy
+# b3NvZnQgQ29ycG9yYXRpb24xKDAmBgNVBAMTH01pY3Jvc29mdCBDb2RlIFNpZ25p
+# bmcgUENBIDIwMTEwHhcNMjUwNjE5MTgyMTM3WhcNMjYwNjE3MTgyMTM3WjB0MQsw
+# CQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9u
+# ZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMR4wHAYDVQQDExVNaWNy
+# b3NvZnQgQ29ycG9yYXRpb24wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
+# AQDASkh1cpvuUqfbqxele7LCSHEamVNBfFE4uY1FkGsAdUF/vnjpE1dnAD9vMOqy
+# 5ZO49ILhP4jiP/P2Pn9ao+5TDtKmcQ+pZdzbG7t43yRXJC3nXvTGQroodPi9USQi
+# 9rI+0gwuXRKBII7L+k3kMkKLmFrsWUjzgXVCLYa6ZH7BCALAcJWZTwWPoiT4HpqQ
+# hJcYLB7pfetAVCeBEVZD8itKQ6QA5/LQR+9X6dlSj4Vxta4JnpxvgSrkjXCz+tlJ
+# 67ABZ551lw23RWU1uyfgCfEFhBfiyPR2WSjskPl9ap6qrf8fNQ1sGYun2p4JdXxe
+# UAKf1hVa/3TQXjvPTiRXCnJPAgMBAAGjggFzMIIBbzAfBgNVHSUEGDAWBgorBgEE
+# AYI3TAgBBggrBgEFBQcDAzAdBgNVHQ4EFgQUuCZyGiCuLYE0aU7j5TFqY05kko0w
+# RQYDVR0RBD4wPKQ6MDgxHjAcBgNVBAsTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEW
+# MBQGA1UEBRMNMjMwMDEyKzUwNTM1OTAfBgNVHSMEGDAWgBRIbmTlUAXTgqoXNzci
+# tW2oynUClTBUBgNVHR8ETTBLMEmgR6BFhkNodHRwOi8vd3d3Lm1pY3Jvc29mdC5j
+# b20vcGtpb3BzL2NybC9NaWNDb2RTaWdQQ0EyMDExXzIwMTEtMDctMDguY3JsMGEG
+# CCsGAQUFBwEBBFUwUzBRBggrBgEFBQcwAoZFaHR0cDovL3d3dy5taWNyb3NvZnQu
+# Y29tL3BraW9wcy9jZXJ0cy9NaWNDb2RTaWdQQ0EyMDExXzIwMTEtMDctMDguY3J0
+# MAwGA1UdEwEB/wQCMAAwDQYJKoZIhvcNAQELBQADggIBACjmqAp2Ci4sTHZci+qk
+# tEAKsFk5HNVGKyWR2rFGXsd7cggZ04H5U4SV0fAL6fOE9dLvt4I7HBHLhpGdE5Uj
+# Ly4NxLTG2bDAkeAVmxmd2uKWVGKym1aarDxXfv3GCN4mRX+Pn4c+py3S/6Kkt5eS
+# DAIIsrzKw3Kh2SW1hCwXX/k1v4b+NH1Fjl+i/xPJspXCFuZB4aC5FLT5fgbRKqns
+# WeAdn8DsrYQhT3QXLt6Nv3/dMzv7G/Cdpbdcoul8FYl+t3dmXM+SIClC3l2ae0wO
+# lNrQ42yQEycuPU5OoqLT85jsZ7+4CaScfFINlO7l7Y7r/xauqHbSPQ1r3oIC+e71
+# 5s2G3ClZa3y99aYx2lnXYe1srcrIx8NAXTViiypXVn9ZGmEkfNcfDiqGQwkml5z9
+# nm3pWiBZ69adaBBbAFEjyJG4y0a76bel/4sDCVvaZzLM3TFbxVO9BQrjZRtbJZbk
+# C3XArpLqZSfx53SuYdddxPX8pvcqFuEu8wcUeD05t9xNbJ4TtdAECJlEi0vvBxlm
+# M5tzFXy2qZeqPMXHSQYqPgZ9jvScZ6NwznFD0+33kbzyhOSz/WuGbAu4cHZG8gKn
+# lQVT4uA2Diex9DMs2WHiokNknYlLoUeWXW1QrJLpqO82TLyKTbBM/oZHAdIc0kzo
+# STro9b3+vjn2809D0+SOOCVZMIIHejCCBWKgAwIBAgIKYQ6Q0gAAAAAAAzANBgkq
+# hkiG9w0BAQsFADCBiDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hpbmd0b24x
+# EDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlv
+# bjEyMDAGA1UEAxMpTWljcm9zb2Z0IFJvb3QgQ2VydGlmaWNhdGUgQXV0aG9yaXR5
+# IDIwMTEwHhcNMTEwNzA4MjA1OTA5WhcNMjYwNzA4MjEwOTA5WjB+MQswCQYDVQQG
+# EwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwG
+# A1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSgwJgYDVQQDEx9NaWNyb3NvZnQg
+# Q29kZSBTaWduaW5nIFBDQSAyMDExMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIIC
+# CgKCAgEAq/D6chAcLq3YbqqCEE00uvK2WCGfQhsqa+laUKq4BjgaBEm6f8MMHt03
+# a8YS2AvwOMKZBrDIOdUBFDFC04kNeWSHfpRgJGyvnkmc6Whe0t+bU7IKLMOv2akr
+# rnoJr9eWWcpgGgXpZnboMlImEi/nqwhQz7NEt13YxC4Ddato88tt8zpcoRb0Rrrg
+# OGSsbmQ1eKagYw8t00CT+OPeBw3VXHmlSSnnDb6gE3e+lD3v++MrWhAfTVYoonpy
+# 4BI6t0le2O3tQ5GD2Xuye4Yb2T6xjF3oiU+EGvKhL1nkkDstrjNYxbc+/jLTswM9
+# sbKvkjh+0p2ALPVOVpEhNSXDOW5kf1O6nA+tGSOEy/S6A4aN91/w0FK/jJSHvMAh
+# dCVfGCi2zCcoOCWYOUo2z3yxkq4cI6epZuxhH2rhKEmdX4jiJV3TIUs+UsS1Vz8k
+# A/DRelsv1SPjcF0PUUZ3s/gA4bysAoJf28AVs70b1FVL5zmhD+kjSbwYuER8ReTB
+# w3J64HLnJN+/RpnF78IcV9uDjexNSTCnq47f7Fufr/zdsGbiwZeBe+3W7UvnSSmn
+# Eyimp31ngOaKYnhfsi+E11ecXL93KCjx7W3DKI8sj0A3T8HhhUSJxAlMxdSlQy90
+# lfdu+HggWCwTXWCVmj5PM4TasIgX3p5O9JawvEagbJjS4NaIjAsCAwEAAaOCAe0w
+# ggHpMBAGCSsGAQQBgjcVAQQDAgEAMB0GA1UdDgQWBBRIbmTlUAXTgqoXNzcitW2o
+# ynUClTAZBgkrBgEEAYI3FAIEDB4KAFMAdQBiAEMAQTALBgNVHQ8EBAMCAYYwDwYD
+# VR0TAQH/BAUwAwEB/zAfBgNVHSMEGDAWgBRyLToCMZBDuRQFTuHqp8cx0SOJNDBa
+# BgNVHR8EUzBRME+gTaBLhklodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20vcGtpL2Ny
+# bC9wcm9kdWN0cy9NaWNSb29DZXJBdXQyMDExXzIwMTFfMDNfMjIuY3JsMF4GCCsG
+# AQUFBwEBBFIwUDBOBggrBgEFBQcwAoZCaHR0cDovL3d3dy5taWNyb3NvZnQuY29t
+# L3BraS9jZXJ0cy9NaWNSb29DZXJBdXQyMDExXzIwMTFfMDNfMjIuY3J0MIGfBgNV
+# HSAEgZcwgZQwgZEGCSsGAQQBgjcuAzCBgzA/BggrBgEFBQcCARYzaHR0cDovL3d3
+# dy5taWNyb3NvZnQuY29tL3BraW9wcy9kb2NzL3ByaW1hcnljcHMuaHRtMEAGCCsG
+# AQUFBwICMDQeMiAdAEwAZQBnAGEAbABfAHAAbwBsAGkAYwB5AF8AcwB0AGEAdABl
+# AG0AZQBuAHQALiAdMA0GCSqGSIb3DQEBCwUAA4ICAQBn8oalmOBUeRou09h0ZyKb
+# C5YR4WOSmUKWfdJ5DJDBZV8uLD74w3LRbYP+vj/oCso7v0epo/Np22O/IjWll11l
+# hJB9i0ZQVdgMknzSGksc8zxCi1LQsP1r4z4HLimb5j0bpdS1HXeUOeLpZMlEPXh6
+# I/MTfaaQdION9MsmAkYqwooQu6SpBQyb7Wj6aC6VoCo/KmtYSWMfCWluWpiW5IP0
+# wI/zRive/DvQvTXvbiWu5a8n7dDd8w6vmSiXmE0OPQvyCInWH8MyGOLwxS3OW560
+# STkKxgrCxq2u5bLZ2xWIUUVYODJxJxp/sfQn+N4sOiBpmLJZiWhub6e3dMNABQam
+# ASooPoI/E01mC8CzTfXhj38cbxV9Rad25UAqZaPDXVJihsMdYzaXht/a8/jyFqGa
+# J+HNpZfQ7l1jQeNbB5yHPgZ3BtEGsXUfFL5hYbXw3MYbBL7fQccOKO7eZS/sl/ah
+# XJbYANahRr1Z85elCUtIEJmAH9AAKcWxm6U/RXceNcbSoqKfenoi+kiVH6v7RyOA
+# 9Z74v2u3S5fi63V4GuzqN5l5GEv/1rMjaHXmr/r8i+sLgOppO6/8MO0ETI7f33Vt
+# Y5E90Z1WTk+/gFcioXgRMiF670EKsT/7qMykXcGhiJtXcVZOSEXAQsmbdlsKgEhr
+# /Xmfwb1tbWrJUnMTDXpQzTGCGgowghoGAgEBMIGVMH4xCzAJBgNVBAYTAlVTMRMw
+# EQYDVQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVN
+# aWNyb3NvZnQgQ29ycG9yYXRpb24xKDAmBgNVBAMTH01pY3Jvc29mdCBDb2RlIFNp
+# Z25pbmcgUENBIDIwMTECEzMAAASFXpnsDlkvzdcAAAAABIUwDQYJYIZIAWUDBAIB
+# BQCgga4wGQYJKoZIhvcNAQkDMQwGCisGAQQBgjcCAQQwHAYKKwYBBAGCNwIBCzEO
+# MAwGCisGAQQBgjcCARUwLwYJKoZIhvcNAQkEMSIEID8/Z0hz8wCpH2YjVYR3wACO
+# qi7toMi0S892RCpCiXnDMEIGCisGAQQBgjcCAQwxNDAyoBSAEgBNAGkAYwByAG8A
+# cwBvAGYAdKEagBhodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20wDQYJKoZIhvcNAQEB
+# BQAEggEAR3ofVJe8H1PSnVv5GEV/iNRKzDHBYXTNKjw6gaEwywGiLnvok4fIy+o/
+# pgoyuM4RLT6jq9o/62LWZPnRCXiQiidnt9u6BtjAQFoy9Hyz39SnG3SIfcXwQU6S
+# Kn6sdIdkCnp9zgCw0A1um1l9ZESP36cub7lCkog6Qd1N+d5KAMuDMHX4MybWYjva
+# YmW+c3RMH4HoBd6igF/hUaz0VTf+yrdIUaBIJ9UlWTMVkwokmQ9I79IwPU5hHnRu
+# Ao8D6p++BagDKmVHo4bY/ADy4GDn4nrLA09mwd0YQPDZvb3K3Z2rIABM0UdS4+lG
+# c/pZsaRUT7TE8NzWXP+vWQ9bdkhNbaGCF5QwgheQBgorBgEEAYI3AwMBMYIXgDCC
+# F3wGCSqGSIb3DQEHAqCCF20wghdpAgEDMQ8wDQYJYIZIAWUDBAIBBQAwggFSBgsq
+# hkiG9w0BCRABBKCCAUEEggE9MIIBOQIBAQYKKwYBBAGEWQoDATAxMA0GCWCGSAFl
+# AwQCAQUABCAd+KomD6n/vMp0PpchU0Vc9uK1oIZ/s0smWP9W6KAY4QIGaSc7gduW
+# GBMyMDI1MTIxMDIyNDQ0NC41NjdaMASAAgH0oIHRpIHOMIHLMQswCQYDVQQGEwJV
+# UzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UE
+# ChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSUwIwYDVQQLExxNaWNyb3NvZnQgQW1l
+# cmljYSBPcGVyYXRpb25zMScwJQYDVQQLEx5uU2hpZWxkIFRTUyBFU046REMwMC0w
+# NUUwLUQ5NDcxJTAjBgNVBAMTHE1pY3Jvc29mdCBUaW1lLVN0YW1wIFNlcnZpY2Wg
+# ghHqMIIHIDCCBQigAwIBAgITMwAAAgO7HlwAOGx0ygABAAACAzANBgkqhkiG9w0B
+# AQsFADB8MQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UE
+# BxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSYwJAYD
+# VQQDEx1NaWNyb3NvZnQgVGltZS1TdGFtcCBQQ0EgMjAxMDAeFw0yNTAxMzAxOTQy
+# NDZaFw0yNjA0MjIxOTQyNDZaMIHLMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2Fz
+# aGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDEeMBwGA1UEChMVTWljcm9zb2Z0IENv
+# cnBvcmF0aW9uMSUwIwYDVQQLExxNaWNyb3NvZnQgQW1lcmljYSBPcGVyYXRpb25z
+# MScwJQYDVQQLEx5uU2hpZWxkIFRTUyBFU046REMwMC0wNUUwLUQ5NDcxJTAjBgNV
+# BAMTHE1pY3Jvc29mdCBUaW1lLVN0YW1wIFNlcnZpY2UwggIiMA0GCSqGSIb3DQEB
+# AQUAA4ICDwAwggIKAoICAQChl0MH5wAnOx8Uh8RtidF0J0yaFDHJYHTpPvRR16X1
+# KxGDYfT8PrcGjCLCiaOu3K1DmUIU4Rc5olndjappNuOgzwUoj43VbbJx5PFTY/a1
+# Z80tpqVP0OoKJlUkfDPSBLFgXWj6VgayRCINtLsUasy0w5gysD7ILPZuiQjace5K
+# xASjKf2MVX1qfEzYBbTGNEijSQCKwwyc0eavr4Fo3X/+sCuuAtkTWissU64k8rK6
+# 0jsGRApiESdfuHr0yWAmc7jTOPNeGAx6KCL2ktpnGegLDd1IlE6Bu6BSwAIFHr7z
+# OwIlFqyQuCe0SQALCbJhsT9y9iy61RJAXsU0u0TC5YYmTSbEI7g10dYx8Uj+vh9I
+# nLoKYC5DpKb311bYVd0bytbzlfTRslRTJgotnfCAIGMLqEqk9/2VRGu9klJi1j9n
+# VfqyYHYrMPOBXcrQYW0jmKNjOL47CaEArNzhDBia1wXdJANKqMvJ8pQe2m8/ciby
+# DM+1BVZquNAov9N4tJF4ACtjX0jjXNDUMtSZoVFQH+FkWdfPWx1uBIkc97R+xRLu
+# PjUypHZ5A3AALSke4TaRBvbvTBYyW2HenOT7nYLKTO4jw5Qq6cw3Z9zTKSPQ6D5l
+# yiYpes5RR2MdMvJS4fCcPJFeaVOvuWFSQ/EGtVBShhmLB+5ewzFzdpf1UuJmuOQT
+# TwIDAQABo4IBSTCCAUUwHQYDVR0OBBYEFLIpWUB+EeeQ29sWe0VdzxWQGJJ9MB8G
+# A1UdIwQYMBaAFJ+nFV0AXmJdg/Tl0mWnG1M1GelyMF8GA1UdHwRYMFYwVKBSoFCG
+# Tmh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2lvcHMvY3JsL01pY3Jvc29mdCUy
+# MFRpbWUtU3RhbXAlMjBQQ0ElMjAyMDEwKDEpLmNybDBsBggrBgEFBQcBAQRgMF4w
+# XAYIKwYBBQUHMAKGUGh0dHA6Ly93d3cubWljcm9zb2Z0LmNvbS9wa2lvcHMvY2Vy
+# dHMvTWljcm9zb2Z0JTIwVGltZS1TdGFtcCUyMFBDQSUyMDIwMTAoMSkuY3J0MAwG
+# A1UdEwEB/wQCMAAwFgYDVR0lAQH/BAwwCgYIKwYBBQUHAwgwDgYDVR0PAQH/BAQD
+# AgeAMA0GCSqGSIb3DQEBCwUAA4ICAQCQEMbesD6TC08R0oYCdSC452AQrGf/O89G
+# Q54CtgEsbxzwGDVUcmjXFcnaJSTNedBKVXkBgawRonP1LgxH4bzzVj2eWNmzGIwO
+# 1FlhldAPOHAzLBEHRoSZ4pddFtaQxoabU/N1vWyICiN60It85gnF5JD4MMXyd6pS
+# 8eADIi6TtjfgKPoumWa0BFQ/aEzjUrfPN1r7crK+qkmLztw/ENS7zemfyx4kGRgw
+# Y1WBfFqm/nFlJDPQBicqeU3dOp9hj7WqD0Rc+/4VZ6wQjesIyCkv5uhUNy2LhNDi
+# 2leYtAiIFpmjfNk4GngLvC2Tj9IrOMv20Srym5J/Fh7yWAiPeGs3yA3QapjZTtfr
+# 7NfzpBIJQ4xT/ic4WGWqhGlRlVBI5u6Ojw3ZxSZCLg3vRC4KYypkh8FdIWoKirji
+# dEGlXsNOo+UP/YG5KhebiudTBxGecfJCuuUspIdRhStHAQsjv/dAqWBLlhorq2OC
+# aP+wFhE3WPgnnx5pflvlujocPgsN24++ddHrl3O1FFabW8m0UkDHSKCh8QTwTkYO
+# wu99iExBVWlbYZRz2qOIBjL/ozEhtCB0auKhfTLLeuNGBUaBz+oZZ+X9UAECoMhk
+# ETjb6YfNaI1T7vVAaiuhBoV/JCOQT+RYZrgykyPpzpmwMNFBD1vdW/29q9nkTWoE
+# hcEOO0L9NzCCB3EwggVZoAMCAQICEzMAAAAVxedrngKbSZkAAAAAABUwDQYJKoZI
+# hvcNAQELBQAwgYgxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpXYXNoaW5ndG9uMRAw
+# DgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNyb3NvZnQgQ29ycG9yYXRpb24x
+# MjAwBgNVBAMTKU1pY3Jvc29mdCBSb290IENlcnRpZmljYXRlIEF1dGhvcml0eSAy
+# MDEwMB4XDTIxMDkzMDE4MjIyNVoXDTMwMDkzMDE4MzIyNVowfDELMAkGA1UEBhMC
+# VVMxEzARBgNVBAgTCldhc2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNV
+# BAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEmMCQGA1UEAxMdTWljcm9zb2Z0IFRp
+# bWUtU3RhbXAgUENBIDIwMTAwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoIC
+# AQDk4aZM57RyIQt5osvXJHm9DtWC0/3unAcH0qlsTnXIyjVX9gF/bErg4r25Phdg
+# M/9cT8dm95VTcVrifkpa/rg2Z4VGIwy1jRPPdzLAEBjoYH1qUoNEt6aORmsHFPPF
+# dvWGUNzBRMhxXFExN6AKOG6N7dcP2CZTfDlhAnrEqv1yaa8dq6z2Nr41JmTamDu6
+# GnszrYBbfowQHJ1S/rboYiXcag/PXfT+jlPP1uyFVk3v3byNpOORj7I5LFGc6XBp
+# Dco2LXCOMcg1KL3jtIckw+DJj361VI/c+gVVmG1oO5pGve2krnopN6zL64NF50Zu
+# yjLVwIYwXE8s4mKyzbnijYjklqwBSru+cakXW2dg3viSkR4dPf0gz3N9QZpGdc3E
+# XzTdEonW/aUgfX782Z5F37ZyL9t9X4C626p+Nuw2TPYrbqgSUei/BQOj0XOmTTd0
+# lBw0gg/wEPK3Rxjtp+iZfD9M269ewvPV2HM9Q07BMzlMjgK8QmguEOqEUUbi0b1q
+# GFphAXPKZ6Je1yh2AuIzGHLXpyDwwvoSCtdjbwzJNmSLW6CmgyFdXzB0kZSU2LlQ
+# +QuJYfM2BjUYhEfb3BvR/bLUHMVr9lxSUV0S2yW6r1AFemzFER1y7435UsSFF5PA
+# PBXbGjfHCBUYP3irRbb1Hode2o+eFnJpxq57t7c+auIurQIDAQABo4IB3TCCAdkw
+# EgYJKwYBBAGCNxUBBAUCAwEAATAjBgkrBgEEAYI3FQIEFgQUKqdS/mTEmr6CkTxG
+# NSnPEP8vBO4wHQYDVR0OBBYEFJ+nFV0AXmJdg/Tl0mWnG1M1GelyMFwGA1UdIARV
+# MFMwUQYMKwYBBAGCN0yDfQEBMEEwPwYIKwYBBQUHAgEWM2h0dHA6Ly93d3cubWlj
+# cm9zb2Z0LmNvbS9wa2lvcHMvRG9jcy9SZXBvc2l0b3J5Lmh0bTATBgNVHSUEDDAK
+# BggrBgEFBQcDCDAZBgkrBgEEAYI3FAIEDB4KAFMAdQBiAEMAQTALBgNVHQ8EBAMC
+# AYYwDwYDVR0TAQH/BAUwAwEB/zAfBgNVHSMEGDAWgBTV9lbLj+iiXGJo0T2UkFvX
+# zpoYxDBWBgNVHR8ETzBNMEugSaBHhkVodHRwOi8vY3JsLm1pY3Jvc29mdC5jb20v
+# cGtpL2NybC9wcm9kdWN0cy9NaWNSb29DZXJBdXRfMjAxMC0wNi0yMy5jcmwwWgYI
+# KwYBBQUHAQEETjBMMEoGCCsGAQUFBzAChj5odHRwOi8vd3d3Lm1pY3Jvc29mdC5j
+# b20vcGtpL2NlcnRzL01pY1Jvb0NlckF1dF8yMDEwLTA2LTIzLmNydDANBgkqhkiG
+# 9w0BAQsFAAOCAgEAnVV9/Cqt4SwfZwExJFvhnnJL/Klv6lwUtj5OR2R4sQaTlz0x
+# M7U518JxNj/aZGx80HU5bbsPMeTCj/ts0aGUGCLu6WZnOlNN3Zi6th542DYunKmC
+# VgADsAW+iehp4LoJ7nvfam++Kctu2D9IdQHZGN5tggz1bSNU5HhTdSRXud2f8449
+# xvNo32X2pFaq95W2KFUn0CS9QKC/GbYSEhFdPSfgQJY4rPf5KYnDvBewVIVCs/wM
+# nosZiefwC2qBwoEZQhlSdYo2wh3DYXMuLGt7bj8sCXgU6ZGyqVvfSaN0DLzskYDS
+# PeZKPmY7T7uG+jIa2Zb0j/aRAfbOxnT99kxybxCrdTDFNLB62FD+CljdQDzHVG2d
+# Y3RILLFORy3BFARxv2T5JL5zbcqOCb2zAVdJVGTZc9d/HltEAY5aGZFrDZ+kKNxn
+# GSgkujhLmm77IVRrakURR6nxt67I6IleT53S0Ex2tVdUCbFpAUR+fKFhbHP+Crvs
+# QWY9af3LwUFJfn6Tvsv4O+S3Fb+0zj6lMVGEvL8CwYKiexcdFYmNcP7ntdAoGokL
+# jzbaukz5m/8K6TT4JDVnK+ANuOaMmdbhIurwJ0I9JZTmdHRbatGePu1+oDEzfbzL
+# 6Xu/OHBE0ZDxyKs6ijoIYn/ZcGNTTY3ugm2lBRDBcQZqELQdVTNYs6FwZvKhggNN
+# MIICNQIBATCB+aGB0aSBzjCByzELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldhc2hp
+# bmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jw
+# b3JhdGlvbjElMCMGA1UECxMcTWljcm9zb2Z0IEFtZXJpY2EgT3BlcmF0aW9uczEn
+# MCUGA1UECxMeblNoaWVsZCBUU1MgRVNOOkRDMDAtMDVFMC1EOTQ3MSUwIwYDVQQD
+# ExxNaWNyb3NvZnQgVGltZS1TdGFtcCBTZXJ2aWNloiMKAQEwBwYFKw4DAhoDFQDN
+# rxRX/iz6ss1lBCXG8P1LFxD0e6CBgzCBgKR+MHwxCzAJBgNVBAYTAlVTMRMwEQYD
+# VQQIEwpXYXNoaW5ndG9uMRAwDgYDVQQHEwdSZWRtb25kMR4wHAYDVQQKExVNaWNy
+# b3NvZnQgQ29ycG9yYXRpb24xJjAkBgNVBAMTHU1pY3Jvc29mdCBUaW1lLVN0YW1w
+# IFBDQSAyMDEwMA0GCSqGSIb3DQEBCwUAAgUA7OQtPTAiGA8yMDI1MTIxMDE3MzI0
+# NVoYDzIwMjUxMjExMTczMjQ1WjB0MDoGCisGAQQBhFkKBAExLDAqMAoCBQDs5C09
+# AgEAMAcCAQACAgjlMAcCAQACAhNOMAoCBQDs5X69AgEAMDYGCisGAQQBhFkKBAIx
+# KDAmMAwGCisGAQQBhFkKAwKgCjAIAgEAAgMHoSChCjAIAgEAAgMBhqAwDQYJKoZI
+# hvcNAQELBQADggEBAFXCcBVLkxGEigIad7gAMsj2+SQdBANpzq4qPJXOu81TM3HC
+# rAkCUTm3FRNc6YPdpfvl07lGlv/NHFCLyXL20d6PZ/1wlF5+WR2OvWjrktwDxYv8
+# cZqk7BrV9SB8xBe/GwVi7smKmlXhznqA6lFPO+VNfOwWcxn0H2yxEsAJKyDmgx/7
+# M8xnMTKeK8ulgSy4EoyGgFIO+nGHqxS0yaXe+OgzErkaavB1Qw7jfmm5/wlBCnwz
+# 0UsbaequeL9UjA6FUw3Cc3F+3/D38BzyjJtTxjUVn+QiVWwOfikRJ2F7oZwpsJo3
+# yNIVpwJFpIV6VsqtxzaF0KQZBpS2lBGxVA17pFcxggQNMIIECQIBATCBkzB8MQsw
+# CQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9u
+# ZDEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSYwJAYDVQQDEx1NaWNy
+# b3NvZnQgVGltZS1TdGFtcCBQQ0EgMjAxMAITMwAAAgO7HlwAOGx0ygABAAACAzAN
+# BglghkgBZQMEAgEFAKCCAUowGgYJKoZIhvcNAQkDMQ0GCyqGSIb3DQEJEAEEMC8G
+# CSqGSIb3DQEJBDEiBCApggCahSc04fWyIz1KF4aeejwqHefyj2gzz7p9QsluFTCB
+# +gYLKoZIhvcNAQkQAi8xgeowgecwgeQwgb0EIEsD3RtxlvaTxFOZZnpQw0DksPmV
+# duo5SyK9h9w++hMtMIGYMIGApH4wfDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCldh
+# c2hpbmd0b24xEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBD
+# b3Jwb3JhdGlvbjEmMCQGA1UEAxMdTWljcm9zb2Z0IFRpbWUtU3RhbXAgUENBIDIw
+# MTACEzMAAAIDux5cADhsdMoAAQAAAgMwIgQgwIRXpw5w7cRbWSfOFZ15Z2Nf90Hi
+# Ms/hZSpx+kv4aHcwDQYJKoZIhvcNAQELBQAEggIAM+zwgqPLhBOAumqVnUO/YRh7
+# sePgzUWqveSw/J01TAD8JVXufiGmu4neLrGFki/Nz8ytun2DhJP/3xDRu39y/9Pb
+# t2qKabzaoASwH95fTjHLYEp0PhqkEZ1hkaaYjVC3TAG0LgU2mrvkEjL3doD5MXu8
+# WWQGcnB0Wera/3POf4ylyQbUUnzo/Pl9qUbjPVW/JouzzDzijObLcYp7IDgIDxGL
+# sVJqMgzP1ZWBWsjjx4J0YiYORUnIVKWKPXt/0O3X9VO3zDfOnWRLF8mJj+ybEnqa
+# Wd8LxLJnCxpmTAjtELLgC46UB0N4GHR0+ymSba35Ciz4Kzc+7R9E1Ajy1yd2rmGR
+# M2u/eAV8MvKybIzgTd9Lukk9KJ5lvzV52CuYyzHOzYgcNt/mFgvM6gfMAef3CeN0
+# EU7ECvTEYqno7krSRi6+HD+R14+7EwXbiR0E+KAB2Ppgj7GqHWKeL/Owyv0A1oEa
+# 4ocdqMApLcY908U7IzNu5qo7PPas/RBsB9J52++fyZ/9RyP31IYKu8/5xI5Ef7aH
+# XIopbEpuMHpHeuWlYWlfkULa5tjk4iPVCTRVsgn7IimLY/wgVOLL4ueOzZZ6aNws
+# Q37w/ocvXIH/qXUllulfh5vINVYqXK3d+l0QT8LCMIxXpJSSgtcFcPJG6aSdOFRQ
+# r6EOj+C9DH5MueMd9SY=
+# SIG # End signature block

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.403",
+    "rollForward": "latestFeature"
+  }
+}

--- a/protoc-gen-fsgrpc/Tests/Tests.fsproj
+++ b/protoc-gen-fsgrpc/Tests/Tests.fsproj
@@ -15,10 +15,11 @@
     <None Include="inputs/**">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="$(NugetPackageRoot)/fsgrpc.tools/0.6.2/build/native/**">
+    <!-- Align test tooling with generator dependency (FsGrpc.Tools 0.8.0) -->
+    <None Include="$(NugetPackageRoot)/fsgrpc.tools/0.8.0/build/native/**">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="$(NugetPackageRoot)/fsgrpc.tools/0.6.2/tools/**">
+    <None Include="$(NugetPackageRoot)/fsgrpc.tools/0.8.0/tools/**">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="reference/**">
@@ -41,7 +42,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FSharp.Control.AsyncSeq" Version="3.2.1" />
-    <PackageReference Include="FsGrpc.Tools" Version="0.6.2" />
+    <!-- Use FsGrpc.Tools 0.8.0 to match generator and its Google.Protobuf dependency -->
+    <PackageReference Include="FsGrpc.Tools" Version="0.8.0" />
+    <!-- Pin Google.Protobuf to 3.33.1 to avoid assembly conflicts -->
+    <PackageReference Include="Google.Protobuf" Version="3.33.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/protoc-gen-fsgrpc/protoc-gen-fsgrpc.fsproj
+++ b/protoc-gen-fsgrpc/protoc-gen-fsgrpc.fsproj
@@ -18,8 +18,13 @@
     <RuntimeIdentifiers>linux-arm64;linux-x64;osx-x64;osx-arm64;win-x86;win-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
+  <!-- Avoid loading Protobuf MSBuild tasks during VS design-time build -->
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+    <DisableProtobufDesignTimeBuild>true</DisableProtobufDesignTimeBuild>
+  </PropertyGroup>
+
   <ItemGroup>
-    <Protobuf Include="protoc-proto/**/*.proto" ProtoRoot="protoc-proto"/>
+    <Protobuf Include="protoc-proto/**/*.proto" ProtoRoot="protoc-proto" />
   </ItemGroup>
 
   <ItemGroup>
@@ -34,8 +39,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FsGrpc.Tools" Version="0.6.2" PrivateAssets="all" />
+    <PackageReference Include="FsGrpc.Tools" Version="0.8.0" PrivateAssets="all" />
     <PackageReference Include="Focal.Core" Version="0.10.0" />
+    <PackageReference Update="FSharp.Core" Version="8.0.403" />
 
     <None Include="$(OutputPath)\linux-arm64\*" Pack="true" PackagePath="tools\linux_arm64" Visible="false" />
     <None Include="$(OutputPath)\linux-x64\*" Pack="true" PackagePath="tools\linux_x64" Visible="false" />

--- a/protoc-gen-fsgrpc/test_build.ps1
+++ b/protoc-gen-fsgrpc/test_build.ps1
@@ -1,10 +1,10 @@
 dotnet restore
 
-dotnet build -p:TargetFramework=net6.0 --no-self-contained --configuration Release --no-restore -r linux-arm64 
-dotnet build -p:TargetFramework=net6.0 --no-self-contained --configuration Release --no-restore -r linux-x64
-dotnet build -p:TargetFramework=net6.0 --no-self-contained --configuration Release --no-restore -r osx-x64
-dotnet build -p:TargetFramework=net6.0 --no-self-contained --configuration Release --no-restore -r osx-arm64
-dotnet build -p:TargetFramework=net6.0 --no-self-contained --configuration Release --no-restore -r win-x86
-dotnet build -p:TargetFramework=net6.0 --no-self-contained --configuration Release --no-restore -r win-x64
+dotnet build -p:TargetFramework=net8.0 --no-self-contained --configuration Release --no-restore -r linux-arm64 
+dotnet build -p:TargetFramework=net8.0 --no-self-contained --configuration Release --no-restore -r linux-x64
+dotnet build -p:TargetFramework=net8.0 --no-self-contained --configuration Release --no-restore -r osx-x64
+dotnet build -p:TargetFramework=net8.0 --no-self-contained --configuration Release --no-restore -r osx-arm64
+dotnet build -p:TargetFramework=net8.0 --no-self-contained --configuration Release --no-restore -r win-x86
+dotnet build -p:TargetFramework=net8.0 --no-self-contained --configuration Release --no-restore -r win-x64
 
 dotnet pack -p:PROTOCGENFSGRPC_VERSION=0.5.4-prerelease --configuration=Release -o=artifacts --no-restore --no-build

--- a/struct-support-implementation-guide.md
+++ b/struct-support-implementation-guide.md
@@ -1,0 +1,309 @@
+# Struct Support Implementation Guide for protoc-gen-fsgrpc
+
+## Context
+
+This document provides instructions for implementing code generation support for `google.protobuf.Struct` and `google.protobuf.Value` types in the `protoc-gen-fsgrpc` code generator.
+
+### Background
+
+The FsGrpc runtime library currently supports most Protocol Buffer well-known types (Duration, Timestamp, Wrappers), but does not generate F# code for `google.protobuf.Struct` and `google.protobuf.Value`. These types are used to represent arbitrary JSON-like structured data in Protocol Buffers.
+
+## Problem Statement
+
+When running `buf generate --include-imports --include-wkt` in the FsGrpc.Tests project, the code generator does not produce F# bindings for:
+- `google.protobuf.Struct`
+- `google.protobuf.Value`
+- `google.protobuf.ListValue`
+- `google.protobuf.NullValue`
+
+This causes compilation errors when trying to use these types in F# code.
+
+### Expected Error
+```
+FS0039: The value, constructor, namespace or type 'Struct' is not defined in 'Google.Protobuf'
+```
+
+## Protocol Buffer Definitions
+
+### struct.proto Structure
+
+```protobuf
+// google/protobuf/struct.proto
+message Struct {
+  map<string, Value> fields = 1;
+}
+
+message Value {
+  oneof kind {
+    NullValue null_value = 1;
+    double number_value = 2;
+    string string_value = 3;
+    bool bool_value = 4;
+    Struct struct_value = 5;
+    ListValue list_value = 6;
+  }
+}
+
+message ListValue {
+  repeated Value values = 1;
+}
+
+enum NullValue {
+  NULL_VALUE = 0;
+}
+```
+
+### Key Characteristics
+
+1. **Recursive Structure**: `Struct` contains `Value`, and `Value` can contain `Struct` (mutual recursion)
+2. **Map Field**: `Struct.fields` is a `map<string, Value>`
+3. **Oneof Field**: `Value` is a discriminated union with 6 cases
+4. **Special JSON Serialization**: These types have custom JSON representations per Proto3 JSON spec
+
+## Expected F# Generated Code
+
+### Location
+Generated code should appear in:
+```
+FsGrpc.Tests/gen/google/protobuf/struct.proto.gen.fs
+```
+
+### Expected F# Type Structure
+
+Based on the pattern used for other well-known types in FsGrpc:
+
+```fsharp
+namespace rec Google.Protobuf
+open FsGrpc.Protobuf
+open Google.Protobuf
+#nowarn "40"
+#nowarn "1182"
+
+// NullValue enum
+[<System.Text.Json.Serialization.JsonConverter(typeof<FsGrpc.Json.EnumConverter<NullValue>>)>]
+type NullValue =
+| [<FsGrpc.Protobuf.ProtobufName("NULL_VALUE")>] NullValue = 0
+
+// Value discriminated union (oneof)
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module Value =
+    [<System.Text.Json.Serialization.JsonConverter(typeof<FsGrpc.Json.OneofConverter<Kind>>)>]
+    [<CompilationRepresentation(CompilationRepresentationFlags.UseNullAsTrueValue)>]
+    [<StructuralEquality;StructuralComparison>]
+    [<RequireQualifiedAccess>]
+    type Kind =
+    | None
+    | [<System.Text.Json.Serialization.JsonPropertyName("nullValue")>] NullValue of Google.Protobuf.NullValue
+    | [<System.Text.Json.Serialization.JsonPropertyName("numberValue")>] NumberValue of double
+    | [<System.Text.Json.Serialization.JsonPropertyName("stringValue")>] StringValue of string
+    | [<System.Text.Json.Serialization.JsonPropertyName("boolValue")>] BoolValue of bool
+    | [<System.Text.Json.Serialization.JsonPropertyName("structValue")>] StructValue of Google.Protobuf.Struct
+    | [<System.Text.Json.Serialization.JsonPropertyName("listValue")>] ListValue of Google.Protobuf.ListValue
+
+    type Builder = // ... builder implementation
+
+type private _Value = Value
+[<System.Text.Json.Serialization.JsonConverter(typeof<FsGrpc.Json.MessageConverter>)>]
+[<FsGrpc.Protobuf.Message>]
+[<StructuralEquality;StructuralComparison>]
+type Value = {
+    Kind: Value.Kind
+}
+with
+    static member Proto : Lazy<ProtoDef<Value>> = // ... proto definition
+    static member empty = // ... empty value
+
+// Struct type
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module Struct =
+    type Builder = // ... builder with MapBuilder<string, Value>
+
+type private _Struct = Struct
+[<System.Text.Json.Serialization.JsonConverter(typeof<FsGrpc.Json.MessageConverter>)>]
+[<FsGrpc.Protobuf.Message>]
+[<StructuralEquality;StructuralComparison>]
+type Struct = {
+    [<System.Text.Json.Serialization.JsonPropertyName("fields")>] Fields: Map<string, Value>
+}
+with
+    static member Proto : Lazy<ProtoDef<Struct>> = // ... proto definition
+    static member empty = // ... empty struct
+
+// ListValue type
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module ListValue =
+    type Builder = // ... builder with RepeatedBuilder<Value>
+
+type private _ListValue = ListValue
+[<System.Text.Json.Serialization.JsonConverter(typeof<FsGrpc.Json.MessageConverter>)>]
+[<FsGrpc.Protobuf.Message>]
+[<StructuralEquality;StructuralComparison>]
+type ListValue = {
+    [<System.Text.Json.Serialization.JsonPropertyName("values")>] Values: Value list
+}
+with
+    static member Proto : Lazy<ProtoDef<ListValue>> = // ... proto definition
+    static member empty = // ... empty list value
+```
+
+## Implementation Requirements
+
+### 1. Code Generator Changes
+
+The protoc-gen-fsgrpc plugin needs to:
+
+1. **Process struct.proto**: Ensure `google/protobuf/struct.proto` is included when `--include-wkt` flag is used
+2. **Handle Recursive Types**: Generate forward declarations using `rec` keyword in the namespace
+3. **Generate Map Fields**: Use `MapBuilder<string, Value>` in the Builder and `Map<string, Value>` in the record
+4. **Generate Oneof with Recursive Case**: Handle the `Value.Kind` oneof that contains a `StructValue` case pointing back to `Struct`
+
+### 2. Special Considerations
+
+#### Recursive Type Handling
+```fsharp
+namespace rec Google.Protobuf  // <-- rec keyword needed
+```
+
+#### Builder for Recursive Types
+The Builder needs to handle the mutual recursion:
+```fsharp
+type Builder =
+    struct
+        val mutable Kind: OptionBuilder<Value.Kind>
+    end
+```
+
+#### Proto Definition with Lazy Evaluation
+The `Proto` property must use `lazy` to handle circular dependencies:
+```fsharp
+static member Proto : Lazy<ProtoDef<Value>> =
+    lazy
+    // ... implementation that references Struct.Proto
+```
+
+### 3. JSON Serialization Special Cases
+
+Per Proto3 JSON specification:
+- `Struct` serializes directly as a JSON object (not wrapped)
+- `Value` serializes as the underlying JSON value type (not as an object with a "kind" field)
+- `ListValue` serializes as a JSON array
+- `NullValue` serializes as JSON `null`
+
+This may require custom JSON converters in the FsGrpc runtime library, but the generated code should use the standard converters initially.
+
+## Reference Examples
+
+### Existing Pattern: Oneof with Message Types
+See `gen/testproto.proto.gen.fs` - `Enums.UnionCase`:
+```fsharp
+type UnionCase =
+| None
+| Color of Test.Name.Space.Enums.Color
+| Name of string
+```
+
+### Existing Pattern: Map Fields
+See `gen/testproto.proto.gen.fs` - `IntMap`:
+```fsharp
+type IntMap = {
+    IntMap: Map<int, string>
+}
+```
+
+### Existing Pattern: Recursive Types
+See `gen/testproto.proto.gen.fs` - `Nest`:
+```fsharp
+type Nest = {
+    Children: Test.Name.Space.Nest list  // Self-referential
+}
+```
+
+### Existing Pattern: Well-Known Types
+See `gen/google/protobuf/wrappers.proto.gen.fs` for how other well-known types are generated.
+
+## Testing Strategy
+
+Once implemented, verify by:
+
+1. Run `buf generate --include-imports --include-wkt` in FsGrpc.Tests directory
+2. Check that `gen/google/protobuf/struct.proto.gen.fs` is created
+3. Build FsGrpc.Tests project - should compile without errors
+4. The test file at `FsGrpc.Tests/JsonTests.fs` has commented-out tests that can be uncommented to verify functionality
+
+## Test Cases to Enable
+
+Location: `FsGrpc.Tests/JsonTests.fs` (lines ~680-720)
+
+```fsharp
+[<Fact>]
+let ``Struct with simple fields serializes to JSON`` () =
+    let structValue = Google.Protobuf.Struct.empty
+    let actual = JsonSerializer.Serialize(structValue, ignoreDefault)
+    let expected = """{}"""
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Struct deserializes from JSON`` () =
+    let json = """{"name":"test","count":42,"active":true}"""
+    let actual : Google.Protobuf.Struct = JsonSerializer.Deserialize(json)
+    Assert.NotNull(actual)
+
+[<Fact>]
+let ``Struct round-trips through JSON`` () =
+    let original = Google.Protobuf.Struct.empty
+    let serialized = JsonSerializer.Serialize(original)
+    let deserialized : Google.Protobuf.Struct = JsonSerializer.Deserialize(serialized)
+    Assert.Equal(original, deserialized)
+```
+
+## Dependencies
+
+### FsGrpc Runtime Support
+The generated code depends on these primitives from `FsGrpc.Protobuf`:
+- `ValueCodec.Double`
+- `ValueCodec.String`
+- `ValueCodec.Bool`
+- `ValueCodec.Enum<NullValue>`
+- `ValueCodec.Message<Struct>` (recursive)
+- `ValueCodec.Message<ListValue>`
+- `FieldCodec.Map` for the fields map
+- `FieldCodec.Repeated` for ListValue.values
+- `FieldCodec.OneofCase` for Value.Kind cases
+- `MapBuilder<'K,'V>`
+- `OptionBuilder<'T>`
+- `RepeatedBuilder<'T>`
+
+These already exist in the FsGrpc runtime, so no changes should be needed there initially.
+
+## Success Criteria
+
+1. ? `struct.proto` is processed by the code generator
+2. ? Generated file `struct.proto.gen.fs` appears in correct location
+3. ? FsGrpc.Tests project compiles without errors
+4. ? `Google.Protobuf.Struct.empty` is accessible from F# code
+5. ? Struct types can be serialized to/from protocol buffer wire format
+6. ? Struct types can be serialized to/from JSON
+7. ? Test cases in JsonTests.fs pass when uncommented
+
+## Questions to Answer During Implementation
+
+1. Does buf/protoc already provide struct.proto, or does it need to be added explicitly?
+2. How does the code generator handle the `rec` keyword for mutually recursive types?
+3. Are there existing test cases in protoc-gen-fsgrpc for recursive message types?
+4. Does the generator need special handling for the Proto3 JSON canonical representation of Struct?
+
+## Next Steps After protoc-gen-fsgrpc Changes
+
+After implementing in protoc-gen-fsgrpc:
+1. Return to FsGrpc repository
+2. Re-run code generation: `cd FsGrpc\FsGrpc.Tests && buf generate --include-imports --include-wkt`
+3. Verify generated code appears
+4. Uncomment tests in `JsonTests.fs`
+5. Run tests to verify functionality
+6. Add any needed runtime support to `FsGrpc\Protobuf.fs` if tests fail
+
+## Additional Resources
+
+- Proto3 JSON Specification: https://protobuf.dev/programming-guides/proto3/#json
+- google.protobuf.Struct documentation: https://protobuf.dev/reference/protobuf/google.protobuf/#struct
+- FsGrpc GitHub: https://github.com/dmgtech/fsgrpc

--- a/struct-support-implementation-guide.md
+++ b/struct-support-implementation-guide.md
@@ -277,13 +277,13 @@ These already exist in the FsGrpc runtime, so no changes should be needed there 
 
 ## Success Criteria
 
-1. ? `struct.proto` is processed by the code generator
-2. ? Generated file `struct.proto.gen.fs` appears in correct location
-3. ? FsGrpc.Tests project compiles without errors
-4. ? `Google.Protobuf.Struct.empty` is accessible from F# code
-5. ? Struct types can be serialized to/from protocol buffer wire format
-6. ? Struct types can be serialized to/from JSON
-7. ? Test cases in JsonTests.fs pass when uncommented
+- [ ] `struct.proto` is processed by the code generator
+- [ ] Generated file `struct.proto.gen.fs` appears in correct location
+- [ ] FsGrpc.Tests project compiles without errors
+- [ ] `Google.Protobuf.Struct.empty` is accessible from F# code
+- [ ] Struct types can be serialized to/from protocol buffer wire format
+- [ ] Struct types can be serialized to/from JSON
+- [ ] Test cases in JsonTests.fs pass when uncommented
 
 ## Questions to Answer During Implementation
 


### PR DESCRIPTION
This pull request upgrades the project to .NET 8 and updates related dependencies, build scripts, and documentation. It also introduces a new implementation guide for adding support for `google.protobuf.Struct` and related types in the F# code generator. The most important changes are:

**.NET 8 Upgrade and Dependency Updates**
- Updated all references to the .NET SDK from version 6.0.x to 8.0.x in the GitHub Actions workflows (`.github/workflows/pr-test.yaml`, `.github/workflows/release-publish.yaml`), the `global.json` SDK version, and the `test_build.ps1` script to target `net8.0` instead of `net6.0`. [[1]](diffhunk://#diff-3803c0daa9306ceec1bc845685e17cd6cdfb2e7530ba2def0e52b5e4e4c36720L19) [[2]](diffhunk://#diff-4840bf03c5880e943d6425efb65654b1ca5fe870a3ff296bc1156b8f9c805e2aL23) [[3]](diffhunk://#diff-8df3cd354bc584349d04ad5675b33c042d8b99b741b8b95af394c55e0f5001bfR1-R6) [[4]](diffhunk://#diff-e1972d2cf36652decd7078d7b947f1d5568327f8ed853cab6d5fcf750961596eL3-R8)
- Updated NuGet package dependencies in `protoc-gen-fsgrpc.fsproj`, including upgrading `FsGrpc.Tools` from 0.6.2 to 0.8.0 and explicitly referencing `FSharp.Core` version 8.0.403 for .NET 8 compatibility.

**Build and Solution Improvements**
- Added a new solution file, `FsGrpc.ProtocGenFsGrpc.sln`, to enable easier development and IDE integration.
- Added a property to `protoc-gen-fsgrpc.fsproj` to disable loading Protobuf MSBuild tasks during Visual Studio design-time builds, improving IDE performance and reliability.

**Documentation**
- Added a comprehensive implementation guide (`struct-support-implementation-guide.md`) detailing how to add code generation support for `google.protobuf.Struct`, `Value`, `ListValue`, and `NullValue` types, including F# code patterns, JSON serialization requirements, and testing strategy.